### PR TITLE
Upgrade to Project Factory 7.0

### DIFF
--- a/examples/cloudbuild_enabled/main.tf
+++ b/examples/cloudbuild_enabled/main.tf
@@ -16,11 +16,11 @@
 
 
 provider "google" {
-  version = "~> 2.12.0"
+  version = "~> 3.5.0"
 }
 
 provider "google-beta" {
-  version = "~> 2.12.0"
+  version = "~> 3.5.0"
 }
 
 provider "null" {

--- a/examples/simple/main.tf
+++ b/examples/simple/main.tf
@@ -15,11 +15,11 @@
  */
 
 provider "google" {
-  version = "~> 2.12.0"
+  version = "~> 3.5.0"
 }
 
 provider "google-beta" {
-  version = "~> 2.12.0"
+  version = "~> 3.5.0"
 }
 
 provider "null" {

--- a/main.tf
+++ b/main.tf
@@ -36,7 +36,7 @@ data "google_organization" "org" {
 
 module "seed_project" {
   source                      = "terraform-google-modules/project-factory/google"
-  version                     = "~> 5.0"
+  version                     = "~> 7.0"
   name                        = local.seed_project_id
   random_project_id           = true
   disable_services_on_destroy = false

--- a/modules/cloudbuild/main.tf
+++ b/modules/cloudbuild/main.tf
@@ -36,7 +36,7 @@ data "google_organization" "org" {
 
 module "cloudbuild_project" {
   source                      = "terraform-google-modules/project-factory/google"
-  version                     = "~> 5.0"
+  version                     = "~> 7.0"
   name                        = local.cloudbuild_project_id
   random_project_id           = true
   disable_services_on_destroy = false

--- a/modules/cloudbuild/variables.tf
+++ b/modules/cloudbuild/variables.tf
@@ -79,7 +79,7 @@ variable "activate_apis" {
     "servicenetworking.googleapis.com",
     "compute.googleapis.com",
     "logging.googleapis.com",
-    "bigquery-json.googleapis.com",
+    "bigquery.googleapis.com",
     "cloudresourcemanager.googleapis.com",
     "cloudbilling.googleapis.com",
     "iam.googleapis.com",

--- a/modules/cloudbuild/versions.tf
+++ b/modules/cloudbuild/versions.tf
@@ -18,7 +18,7 @@ terraform {
   required_version = "~> 0.12.6"
 
   required_providers {
-    google      = "~> 2.1"
-    google-beta = "~> 2.1"
+    google      = "~> 3.5"
+    google-beta = "~> 3.5"
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -68,7 +68,7 @@ variable "activate_apis" {
     "servicenetworking.googleapis.com",
     "compute.googleapis.com",
     "logging.googleapis.com",
-    "bigquery-json.googleapis.com",
+    "bigquery.googleapis.com",
     "cloudresourcemanager.googleapis.com",
     "cloudbilling.googleapis.com",
     "iam.googleapis.com",

--- a/versions.tf
+++ b/versions.tf
@@ -18,7 +18,7 @@ terraform {
   required_version = "~> 0.12.6"
 
   required_providers {
-    google      = "~> 2.1"
-    google-beta = "~> 2.1"
+    google      = ">= 2.1, <4.0"
+    google-beta = ">= 2.1, <4.0"
   }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -18,7 +18,7 @@ terraform {
   required_version = "~> 0.12.6"
 
   required_providers {
-    google      = ">= 2.1, <4.0"
-    google-beta = ">= 2.1, <4.0"
+    google      = "~> 3.3"
+    google-beta = "~> 3.3"
   }
 }


### PR DESCRIPTION
BREAKING CHANGE: Upgrade to Project Factory 7.0, requiring Google Provider 3.x