### PR TITLE
serviceusage api added in the default activate_apis (#10)

### DIFF
--- a/test/integration/cloudbuild_enabled/controls/gcp.rb
+++ b/test/integration/cloudbuild_enabled/controls/gcp.rb
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 default_apis = [
+  "serviceusage.googleapis.com",
   "servicenetworking.googleapis.com",
   "compute.googleapis.com",
   "logging.googleapis.com",

--- a/test/integration/simple/controls/gcp.rb
+++ b/test/integration/simple/controls/gcp.rb
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 default_apis = [
+  "serviceusage.googleapis.com",
   "servicenetworking.googleapis.com",
   "compute.googleapis.com",
   "logging.googleapis.com",

--- a/variables.tf
+++ b/variables.tf
@@ -65,6 +65,7 @@ variable "activate_apis" {
   type        = list(string)
 
   default = [
+    "serviceusage.googleapis.com",
     "servicenetworking.googleapis.com",
     "compute.googleapis.com",
     "logging.googleapis.com",


### PR DESCRIPTION
Just adds serviceusage.googleapis.com in the default activated apis.

issue #10 

Note: I still have an issue for the tests to all pass with linking the billing account but I don't think it is any relevant to this change.