### PR TITLE
skip gcloud download for seed project

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -46,7 +46,7 @@ resource "google_organization_iam_member" "tmp_project_creator" {
 
 module "seed_project" {
   source                      = "terraform-google-modules/project-factory/google"
-  version                     = "~> 7.0"
+  version                     = "~> 7.1"
   name                        = local.seed_project_id
   random_project_id           = true
   disable_services_on_destroy = false
@@ -55,6 +55,8 @@ module "seed_project" {
   billing_account             = var.billing_account
   activate_apis               = local.activate_apis
   labels                      = var.project_labels
+  skip_gcloud_download        = true
+
 }
 
 /******************************************


### PR DESCRIPTION
As the gcloud CLI is declared as a required resource for this to work in the readme, we should skip the download of the gcloud CLI