### PR TITLE
Add skip_gcloud_download for all PF instances

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@
 # Make will use bash instead of sh
 SHELL := /usr/bin/env bash
 
-DOCKER_TAG_VERSION_DEVELOPER_TOOLS := 0.6.0
+DOCKER_TAG_VERSION_DEVELOPER_TOOLS := 0.11.0
 DOCKER_IMAGE_DEVELOPER_TOOLS := cft/developer-tools
 REGISTRY_URL := gcr.io/cloud-foundation-cicd
 

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ For the cloudbuild submodule, see the README [cloudbuild](./modules/cloudbuild).
 | project\_prefix | Name prefix to use for projects created. | string | `"cft"` | no |
 | sa\_enable\_impersonation | Allow org_admins group to impersonate service account & enable APIs required. | bool | `"false"` | no |
 | sa\_org\_iam\_permissions | List of permissions granted to Terraform service account across the GCP organization. | list(string) | `<list>` | no |
+| skip\_gcloud\_download | Whether to skip downloading gcloud (assumes gcloud is already available outside the module) | bool | `"true"` | no |
 | storage\_bucket\_labels | Labels to apply to the storage bucket. | map(string) | `<map>` | no |
 
 ## Outputs

--- a/build/int.cloudbuild.yaml
+++ b/build/int.cloudbuild.yaml
@@ -56,4 +56,4 @@ tags:
 - 'integration'
 substitutions:
   _DOCKER_IMAGE_DEVELOPER_TOOLS: 'cft/developer-tools'
-  _DOCKER_TAG_VERSION_DEVELOPER_TOOLS: '0.6.0'
+  _DOCKER_TAG_VERSION_DEVELOPER_TOOLS: '0.11.0'

--- a/build/lint.cloudbuild.yaml
+++ b/build/lint.cloudbuild.yaml
@@ -21,4 +21,4 @@ tags:
 - 'lint'
 substitutions:
   _DOCKER_IMAGE_DEVELOPER_TOOLS: 'cft/developer-tools'
-  _DOCKER_TAG_VERSION_DEVELOPER_TOOLS: '0.1.0'
+  _DOCKER_TAG_VERSION_DEVELOPER_TOOLS: '0.11.0'

--- a/main.tf
+++ b/main.tf
@@ -46,7 +46,7 @@ resource "google_organization_iam_member" "tmp_project_creator" {
 
 module "seed_project" {
   source                      = "terraform-google-modules/project-factory/google"
-  version                     = "~> 7.0"
+  version                     = "~> 8.0"
   name                        = local.seed_project_id
   random_project_id           = true
   disable_services_on_destroy = false
@@ -55,6 +55,7 @@ module "seed_project" {
   billing_account             = var.billing_account
   activate_apis               = local.activate_apis
   labels                      = var.project_labels
+  skip_gcloud_download        = var.skip_gcloud_download
 }
 
 /******************************************

--- a/modules/cloudbuild/README.md
+++ b/modules/cloudbuild/README.md
@@ -61,6 +61,7 @@ Functional examples and sample Cloud Build definitions are included in the [exam
 | project\_labels | Labels to apply to the project. | map(string) | `<map>` | no |
 | project\_prefix | Name prefix to use for projects created. | string | `"cft"` | no |
 | sa\_enable\_impersonation | Allow org_admins group to impersonate service account & enable APIs required. | bool | `"false"` | no |
+| skip\_gcloud\_download | Whether to skip downloading gcloud (assumes gcloud is already available outside the module) | bool | `"true"` | no |
 | storage\_bucket\_labels | Labels to apply to the storage bucket. | map(string) | `<map>` | no |
 | terraform\_sa\_email | Email for terraform service account. | string | n/a | yes |
 | terraform\_sa\_name | Fully-qualified name of the terraform service account. | string | n/a | yes |

--- a/modules/cloudbuild/main.tf
+++ b/modules/cloudbuild/main.tf
@@ -36,7 +36,7 @@ data "google_organization" "org" {
 
 module "cloudbuild_project" {
   source                      = "terraform-google-modules/project-factory/google"
-  version                     = "~> 7.0"
+  version                     = "~> 8.0"
   name                        = local.cloudbuild_project_id
   random_project_id           = true
   disable_services_on_destroy = false
@@ -45,6 +45,7 @@ module "cloudbuild_project" {
   billing_account             = var.billing_account
   activate_apis               = local.activate_apis
   labels                      = var.project_labels
+  skip_gcloud_download        = var.skip_gcloud_download
 }
 
 resource "google_project_service" "cloudbuild_apis" {

--- a/modules/cloudbuild/variables.tf
+++ b/modules/cloudbuild/variables.tf
@@ -130,3 +130,9 @@ variable "terraform_version_sha256sum" {
   type        = string
   default     = "602d2529aafdaa0f605c06adb7c72cfb585d8aa19b3f4d8d189b42589e27bf11"
 }
+
+variable "skip_gcloud_download" {
+  description = "Whether to skip downloading gcloud (assumes gcloud is already available outside the module)"
+  type        = bool
+  default     = true
+}

--- a/variables.tf
+++ b/variables.tf
@@ -134,3 +134,9 @@ variable "org_project_creators" {
   type        = list(string)
   default     = []
 }
+
+variable "skip_gcloud_download" {
+  description = "Whether to skip downloading gcloud (assumes gcloud is already available outside the module)"
+  type        = bool
+  default     = true
+}


### PR DESCRIPTION
As discussed offline for https://github.com/terraform-google-modules/terraform-example-foundation/issues/61

- Adds skip_gcloud_download for all PF instances defaulting to `true`

- Also bumped PF to latest version