### PR TITLE
feat: Add ability to define custom list of branches to trigger apply …

### DIFF
--- a/modules/cloudbuild/README.md
+++ b/modules/cloudbuild/README.md
@@ -54,6 +54,8 @@ Functional examples and sample Cloud Build definitions are included in the [exam
 | activate\_apis | List of APIs to enable in the Cloudbuild project. | list(string) | `<list>` | no |
 | billing\_account | The ID of the billing account to associate projects with. | string | n/a | yes |
 | cloud\_source\_repos | List of Cloud Source Repo's to create with CloudBuild triggers. | list(string) | `<list>` | no |
+| cloudbuild\_apply\_filename | Path and name of Cloud Build YAML definition used for terraform apply. | string | `"cloudbuild-tf-apply.yaml"` | no |
+| cloudbuild\_plan\_filename | Path and name of Cloud Build YAML definition used for terraform plan. | string | `"cloudbuild-tf-plan.yaml"` | no |
 | default\_region | Default region to create resources where applicable. | string | `"us-central1"` | no |
 | folder\_id | The ID of a folder to host this project | string | `""` | no |
 | group\_org\_admins | Google Group for GCP Organization Administrators | string | n/a | yes |
@@ -63,6 +65,7 @@ Functional examples and sample Cloud Build definitions are included in the [exam
 | sa\_enable\_impersonation | Allow org_admins group to impersonate service account & enable APIs required. | bool | `"false"` | no |
 | skip\_gcloud\_download | Whether to skip downloading gcloud (assumes gcloud is already available outside the module) | bool | `"true"` | no |
 | storage\_bucket\_labels | Labels to apply to the storage bucket. | map(string) | `<map>` | no |
+| terraform\_apply\_branches | List of git branches configured to run terraform apply Cloud Build trigger. All other branches will run plan by default. | list(string) | `<list>` | no |
 | terraform\_sa\_email | Email for terraform service account. | string | n/a | yes |
 | terraform\_sa\_name | Fully-qualified name of the terraform service account. | string | n/a | yes |
 | terraform\_state\_bucket | Default state bucket, used in Cloud Build substitutions. | string | n/a | yes |

--- a/modules/cloudbuild/variables.tf
+++ b/modules/cloudbuild/variables.tf
@@ -136,3 +136,24 @@ variable "skip_gcloud_download" {
   type        = bool
   default     = true
 }
+
+variable "cloudbuild_plan_filename" {
+  description = "Path and name of Cloud Build YAML definition used for terraform plan."
+  type        = string
+  default     = "cloudbuild-tf-plan.yaml"
+}
+
+variable "cloudbuild_apply_filename" {
+  description = "Path and name of Cloud Build YAML definition used for terraform apply."
+  type        = string
+  default     = "cloudbuild-tf-apply.yaml"
+}
+
+variable "terraform_apply_branches" {
+  description = "List of git branches configured to run terraform apply Cloud Build trigger. All other branches will run plan by default."
+  type        = list(string)
+
+  default = [
+    "master"
+  ]
+}


### PR DESCRIPTION
This PR adds the ability to define a custom list of branches which trigger a terraform apply, to make it easier to build a workflow with the new code structure for the foundation example. I have also added an additional substitution for convenience when we eventually have a wrapper shell script.

The existing behavior should be preserved, although it will be using a slightly modified regex so we may need to flag the change as it will modify existing triggers.