### PR TITLE
Replaces deprecated bucket_policy_only for uniform_bucket_level_access

### DIFF
--- a/examples/cloudbuild_enabled/main.tf
+++ b/examples/cloudbuild_enabled/main.tf
@@ -16,7 +16,7 @@
 
 
 provider "google" {
-  version = "~> 3.31.0"
+  version = "~> 3.38.0"
 }
 
 provider "google-beta" {

--- a/examples/simple-folder/main.tf
+++ b/examples/simple-folder/main.tf
@@ -15,7 +15,7 @@
  */
 
 provider "google" {
-  version = "~> 3.31.0"
+  version = "~> 3.38.0"
 }
 
 provider "google-beta" {

--- a/examples/simple/main.tf
+++ b/examples/simple/main.tf
@@ -15,7 +15,7 @@
  */
 
 provider "google" {
-  version = "~> 3.31.0"
+  version = "~> 3.38.0"
 }
 
 provider "google-beta" {

--- a/main.tf
+++ b/main.tf
@@ -80,11 +80,11 @@ resource "google_service_account" "org_terraform" {
  ***********************************************/
 
 resource "google_storage_bucket" "org_terraform_state" {
-  project            = module.seed_project.project_id
-  name               = format("%s-%s-%s", var.project_prefix, "tfstate", random_id.suffix.hex)
-  location           = var.default_region
-  labels             = var.storage_bucket_labels
-  bucket_policy_only = true
+  project                     = module.seed_project.project_id
+  name                        = format("%s-%s-%s", var.project_prefix, "tfstate", random_id.suffix.hex)
+  location                    = var.default_region
+  labels                      = var.storage_bucket_labels
+  uniform_bucket_level_access = true
   versioning {
     enabled = true
   }

--- a/modules/cloudbuild/main.tf
+++ b/modules/cloudbuild/main.tf
@@ -77,11 +77,11 @@ resource "google_project_iam_member" "org_admins_cloudbuild_viewer" {
 *******************************************/
 
 resource "google_storage_bucket" "cloudbuild_artifacts" {
-  project            = module.cloudbuild_project.project_id
-  name               = format("%s-%s-%s", var.project_prefix, "cloudbuild-artifacts", random_id.suffix.hex)
-  location           = var.default_region
-  labels             = var.storage_bucket_labels
-  bucket_policy_only = true
+  project                     = module.cloudbuild_project.project_id
+  name                        = format("%s-%s-%s", var.project_prefix, "cloudbuild-artifacts", random_id.suffix.hex)
+  location                    = var.default_region
+  labels                      = var.storage_bucket_labels
+  uniform_bucket_level_access = true
   versioning {
     enabled = true
   }


### PR DESCRIPTION
Hey folks!

This pull request closes the issue #62 replacing the `bucket_policy_only` for `uniform_bucket_level_access` parameter.

Could you please take a look?

Thanks!