### PR TITLE
feat: Make Cloud Source Repos optional

### DIFF
--- a/modules/cloudbuild/README.md
+++ b/modules/cloudbuild/README.md
@@ -53,9 +53,10 @@ Functional examples and sample Cloud Build definitions are included in the [exam
 |------|-------------|------|---------|:--------:|
 | activate\_apis | List of APIs to enable in the Cloudbuild project. | `list(string)` | <pre>[<br>  "serviceusage.googleapis.com",<br>  "servicenetworking.googleapis.com",<br>  "compute.googleapis.com",<br>  "logging.googleapis.com",<br>  "bigquery.googleapis.com",<br>  "cloudresourcemanager.googleapis.com",<br>  "cloudbilling.googleapis.com",<br>  "iam.googleapis.com",<br>  "admin.googleapis.com",<br>  "appengine.googleapis.com",<br>  "storage-api.googleapis.com"<br>]</pre> | no |
 | billing\_account | The ID of the billing account to associate projects with. | `string` | n/a | yes |
-| cloud\_source\_repos | List of Cloud Source Repo's to create with CloudBuild triggers. | `list(string)` | <pre>[<br>  "gcp-org",<br>  "gcp-networks",<br>  "gcp-projects"<br>]</pre> | no |
+| cloud\_source\_repos | List of Cloud Source Repos to create with CloudBuild triggers. | `list(string)` | <pre>[<br>  "gcp-org",<br>  "gcp-networks",<br>  "gcp-projects"<br>]</pre> | no |
 | cloudbuild\_apply\_filename | Path and name of Cloud Build YAML definition used for terraform apply. | `string` | `"cloudbuild-tf-apply.yaml"` | no |
 | cloudbuild\_plan\_filename | Path and name of Cloud Build YAML definition used for terraform plan. | `string` | `"cloudbuild-tf-plan.yaml"` | no |
+| create\_cloud\_source\_repos | If shared Cloud Source Repos should be created. | `bool` | `true` | no |
 | default\_region | Default region to create resources where applicable. | `string` | `"us-central1"` | no |
 | folder\_id | The ID of a folder to host this project | `string` | `""` | no |
 | group\_org\_admins | Google Group for GCP Organization Administrators | `string` | n/a | yes |

--- a/modules/cloudbuild/main.tf
+++ b/modules/cloudbuild/main.tf
@@ -144,7 +144,7 @@ resource "google_kms_crypto_key_iam_binding" "cloud_build_crypto_key_encrypter" 
 *******************************************/
 
 resource "google_sourcerepo_repository" "gcp_repo" {
-  for_each = toset(var.cloud_source_repos)
+  for_each = var.create_cloud_source_repos ? toset(var.cloud_source_repos) : []
   project  = module.cloudbuild_project.project_id
   name     = each.value
   depends_on = [
@@ -157,6 +157,7 @@ resource "google_sourcerepo_repository" "gcp_repo" {
 *******************************************/
 
 resource "google_project_iam_member" "org_admins_source_repo_admin" {
+  count   = var.create_cloud_source_repos ? 1 : 0
   project = module.cloudbuild_project.project_id
   role    = "roles/source.admin"
   member  = "group:${var.group_org_admins}"
@@ -167,7 +168,7 @@ resource "google_project_iam_member" "org_admins_source_repo_admin" {
  ***********************************************/
 
 resource "google_cloudbuild_trigger" "master_trigger" {
-  for_each    = toset(var.cloud_source_repos)
+  for_each    = var.create_cloud_source_repos ? toset(var.cloud_source_repos) : []
   project     = module.cloudbuild_project.project_id
   description = "${each.value} - terraform apply."
 
@@ -198,7 +199,7 @@ resource "google_cloudbuild_trigger" "master_trigger" {
  ***********************************************/
 
 resource "google_cloudbuild_trigger" "non_master_trigger" {
-  for_each    = toset(var.cloud_source_repos)
+  for_each    = var.create_cloud_source_repos ? toset(var.cloud_source_repos) : []
   project     = module.cloudbuild_project.project_id
   description = "${each.value} - terraform plan."
 

--- a/modules/cloudbuild/variables.tf
+++ b/modules/cloudbuild/variables.tf
@@ -102,8 +102,14 @@ variable "storage_bucket_labels" {
   default     = {}
 }
 
+variable "create_cloud_source_repos" {
+  description = "If shared Cloud Source Repos should be created."
+  type        = bool
+  default     = true
+}
+
 variable "cloud_source_repos" {
-  description = "List of Cloud Source Repo's to create with CloudBuild triggers."
+  description = "List of Cloud Source Repos to create with CloudBuild triggers."
   type        = list(string)
 
   default = [


### PR DESCRIPTION
Adds a new input variable `create_cloud_source_repos` (bool), whether CSR repos should be created. The default value is `true`.

This feature is useful for users that want to trigger Cloud Build outside of CSR (eg. [google_cloudbuild_trigger github](https://www.terraform.io/docs/providers/google/r/cloudbuild_trigger.html#github)).
