### PR TITLE
feat: custom seed project id

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Functional examples are included in the
 
 The Organization Bootstrap module will take the following actions:
 
-1. Create a new GCP seed project using `project_prefix`.
+1. Create a new GCP seed project using `project_prefix`. Use `project_id` if you need to use custom project ID.
 1. Enable APIs in the seed project using `activate_apis`
 1. Create a new service account for terraform in seed project
 1. Create GCS bucket for Terraform state and grant access to service account
@@ -57,6 +57,7 @@ For the cloudbuild submodule, see the README [cloudbuild](./modules/cloudbuild).
 | org\_id | GCP Organization ID | `string` | n/a | yes |
 | org\_project\_creators | Additional list of members to have project creator role accross the organization. Prefix of group: user: or serviceAccount: is required. | `list(string)` | `[]` | no |
 | parent\_folder | GCP parent folder ID in the form folders/{id} | `string` | `""` | no |
+| project\_id | Custom project ID to use for project created. | `string` | `""` | no |
 | project\_labels | Labels to apply to the project. | `map(string)` | `{}` | no |
 | project\_prefix | Name prefix to use for projects created. | `string` | `"cft"` | no |
 | sa\_enable\_impersonation | Allow org\_admins group to impersonate service account & enable APIs required. | `bool` | `false` | no |

--- a/main.tf
+++ b/main.tf
@@ -15,7 +15,7 @@
  */
 
 locals {
-  seed_project_id             = format("%s-%s", var.project_prefix, "seed")
+  seed_project_id             = var.project_id != "" ? var.project_id : format("%s-%s", var.project_prefix, "seed")
   impersonation_apis          = distinct(concat(var.activate_apis, ["serviceusage.googleapis.com", "iamcredentials.googleapis.com"]))
   impersonation_enabled_count = var.sa_enable_impersonation == true ? 1 : 0
   activate_apis               = var.sa_enable_impersonation == true ? local.impersonation_apis : var.activate_apis

--- a/modules/cloudbuild/README.md
+++ b/modules/cloudbuild/README.md
@@ -61,6 +61,7 @@ Functional examples and sample Cloud Build definitions are included in the [exam
 | folder\_id | The ID of a folder to host this project | `string` | `""` | no |
 | group\_org\_admins | Google Group for GCP Organization Administrators | `string` | n/a | yes |
 | org\_id | GCP Organization ID | `string` | n/a | yes |
+| project\_id | Custom project ID to use for project created. | `string` | `""` | no |
 | project\_labels | Labels to apply to the project. | `map(string)` | `{}` | no |
 | project\_prefix | Name prefix to use for projects created. | `string` | `"cft"` | no |
 | sa\_enable\_impersonation | Allow org\_admins group to impersonate service account & enable APIs required. | `bool` | `false` | no |

--- a/modules/cloudbuild/main.tf
+++ b/modules/cloudbuild/main.tf
@@ -15,7 +15,7 @@
  */
 
 locals {
-  cloudbuild_project_id       = format("%s-%s", var.project_prefix, "cloudbuild")
+  cloudbuild_project_id       = var.project_id != "" ? var.project_id : format("%s-%s", var.project_prefix, "cloudbuild")
   cloudbuild_apis             = ["cloudbuild.googleapis.com", "sourcerepo.googleapis.com", "cloudkms.googleapis.com"]
   impersonation_enabled_count = var.sa_enable_impersonation == true ? 1 : 0
   activate_apis               = distinct(var.activate_apis)

--- a/modules/cloudbuild/variables.tf
+++ b/modules/cloudbuild/variables.tf
@@ -71,6 +71,12 @@ variable "project_prefix" {
   default     = "cft"
 }
 
+variable "project_id" {
+  description = "Custom project ID to use for project created."
+  default     = ""
+  type        = string
+}
+
 variable "activate_apis" {
   description = "List of APIs to enable in the Cloudbuild project."
   type        = list(string)

--- a/variables.tf
+++ b/variables.tf
@@ -66,6 +66,12 @@ variable "project_prefix" {
   type        = string
 }
 
+variable "project_id" {
+  description = "Custom project ID to use for project created."
+  default     = ""
+  type        = string
+}
+
 variable "activate_apis" {
   description = "List of APIs to enable in the seed project."
   type        = list(string)


### PR DESCRIPTION
To fix issue #73. Adds a new input variable `project_id` (string) to be able override seed project id. This change is backward compatible. If default value is not changed, we use `project_prefix`. 