### PR TITLE
Remove upper terraform version constraint

### DIFF
--- a/modules/cloudbuild/versions.tf
+++ b/modules/cloudbuild/versions.tf
@@ -15,7 +15,7 @@
  */
 
 terraform {
-  required_version = ">=0.12.20, <0.14"
+  required_version = ">=0.12.20"
 
   required_providers {
     google      = "~> 3.5"

--- a/test/fixtures/cloudbuild_enabled/versions.tf
+++ b/test/fixtures/cloudbuild_enabled/versions.tf
@@ -15,5 +15,5 @@
  */
 
 terraform {
-  required_version = ">=0.12.20, <0.14"
+  required_version = ">=0.12.20"
 }

--- a/versions.tf
+++ b/versions.tf
@@ -15,7 +15,7 @@
  */
 
 terraform {
-  required_version = ">=0.12.20, <0.14"
+  required_version = ">=0.12.20"
 
   required_providers {
     google      = "~> 3.9"


### PR DESCRIPTION
As per
https://www.terraform.io/docs/configuration/version-constraints.html#terraform-core-and-provider-versions,
it is considered best practice not to have an upper version constraint.
Currently this module doesn't work with version 0.14.0