### PR TITLE
feat!: Upgrade google-project-factory to v10, add Terraform 0.13 constraint and module attribution

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@
 # Make will use bash instead of sh
 SHELL := /usr/bin/env bash
 
-DOCKER_TAG_VERSION_DEVELOPER_TOOLS := 0.12.2
+DOCKER_TAG_VERSION_DEVELOPER_TOOLS := 0.13
 DOCKER_IMAGE_DEVELOPER_TOOLS := cft/developer-tools
 REGISTRY_URL := gcr.io/cloud-foundation-cicd
 

--- a/README.md
+++ b/README.md
@@ -62,7 +62,6 @@ For the cloudbuild submodule, see the README [cloudbuild](./modules/cloudbuild).
 | project\_prefix | Name prefix to use for projects created. | `string` | `"cft"` | no |
 | sa\_enable\_impersonation | Allow org\_admins group to impersonate service account & enable APIs required. | `bool` | `false` | no |
 | sa\_org\_iam\_permissions | List of permissions granted to Terraform service account across the GCP organization. | `list(string)` | <pre>[<br>  "roles/billing.user",<br>  "roles/compute.networkAdmin",<br>  "roles/compute.xpnAdmin",<br>  "roles/iam.securityAdmin",<br>  "roles/iam.serviceAccountAdmin",<br>  "roles/logging.configWriter",<br>  "roles/orgpolicy.policyAdmin",<br>  "roles/resourcemanager.folderAdmin",<br>  "roles/resourcemanager.organizationViewer"<br>]</pre> | no |
-| skip\_gcloud\_download | Whether to skip downloading gcloud (assumes gcloud is already available outside the module) | `bool` | `true` | no |
 | storage\_bucket\_labels | Labels to apply to the storage bucket. | `map(string)` | `{}` | no |
 
 ## Outputs
@@ -81,9 +80,8 @@ For the cloudbuild submodule, see the README [cloudbuild](./modules/cloudbuild).
 ### Software
 
 -   [gcloud sdk](https://cloud.google.com/sdk/install) >= 206.0.0
--   [Terraform](https://www.terraform.io/downloads.html) >= 0.12.20
--   [terraform-provider-google] plugin 2.1.x
--   [terraform-provider-google-beta] plugin 2.1.x
+-   [Terraform](https://www.terraform.io/downloads.html) >= 0.13.0
+-   [terraform-provider-google] plugin 3.50.x
 
 ### Permissions
 

--- a/build/int.cloudbuild.yaml
+++ b/build/int.cloudbuild.yaml
@@ -78,4 +78,4 @@ tags:
 - 'integration'
 substitutions:
   _DOCKER_IMAGE_DEVELOPER_TOOLS: 'cft/developer-tools'
-  _DOCKER_TAG_VERSION_DEVELOPER_TOOLS: '0.13.0'
+  _DOCKER_TAG_VERSION_DEVELOPER_TOOLS: '0.13'

--- a/build/int.cloudbuild.yaml
+++ b/build/int.cloudbuild.yaml
@@ -78,4 +78,4 @@ tags:
 - 'integration'
 substitutions:
   _DOCKER_IMAGE_DEVELOPER_TOOLS: 'cft/developer-tools'
-  _DOCKER_TAG_VERSION_DEVELOPER_TOOLS: '0.12.2'
+  _DOCKER_TAG_VERSION_DEVELOPER_TOOLS: '0.13.0'

--- a/build/lint.cloudbuild.yaml
+++ b/build/lint.cloudbuild.yaml
@@ -21,4 +21,4 @@ tags:
 - 'lint'
 substitutions:
   _DOCKER_IMAGE_DEVELOPER_TOOLS: 'cft/developer-tools'
-  _DOCKER_TAG_VERSION_DEVELOPER_TOOLS: '0.13.0'
+  _DOCKER_TAG_VERSION_DEVELOPER_TOOLS: '0.13'

--- a/build/lint.cloudbuild.yaml
+++ b/build/lint.cloudbuild.yaml
@@ -21,4 +21,4 @@ tags:
 - 'lint'
 substitutions:
   _DOCKER_IMAGE_DEVELOPER_TOOLS: 'cft/developer-tools'
-  _DOCKER_TAG_VERSION_DEVELOPER_TOOLS: '0.12.2'
+  _DOCKER_TAG_VERSION_DEVELOPER_TOOLS: '0.13.0'

--- a/examples/cloudbuild_enabled/main.tf
+++ b/examples/cloudbuild_enabled/main.tf
@@ -16,11 +16,7 @@
 
 
 provider "google" {
-  version = "~> 3.43.0"
-}
-
-provider "google-beta" {
-  version = "~> 3.43.0"
+  version = ">= 3.50"
 }
 
 provider "null" {

--- a/examples/simple-folder/main.tf
+++ b/examples/simple-folder/main.tf
@@ -15,11 +15,7 @@
  */
 
 provider "google" {
-  version = "~> 3.43.0"
-}
-
-provider "google-beta" {
-  version = "~> 3.43.0"
+  version = ">= 3.50"
 }
 
 provider "null" {

--- a/examples/simple/main.tf
+++ b/examples/simple/main.tf
@@ -15,11 +15,7 @@
  */
 
 provider "google" {
-  version = "~> 3.43.0"
-}
-
-provider "google-beta" {
-  version = "~> 3.43.0"
+  version = ">= 3.50"
 }
 
 provider "null" {

--- a/main.tf
+++ b/main.tf
@@ -53,7 +53,7 @@ resource "google_folder_iam_member" "tmp_project_creator" {
 
 module "seed_project" {
   source                      = "terraform-google-modules/project-factory/google"
-  version                     = "~> 9.2"
+  version                     = "~> 10.0.1"
   name                        = local.seed_project_id
   random_project_id           = true
   disable_services_on_destroy = false
@@ -62,7 +62,6 @@ module "seed_project" {
   billing_account             = var.billing_account
   activate_apis               = local.activate_apis
   labels                      = var.project_labels
-  skip_gcloud_download        = var.skip_gcloud_download
 }
 
 /******************************************

--- a/modules/cloudbuild/README.md
+++ b/modules/cloudbuild/README.md
@@ -65,7 +65,6 @@ Functional examples and sample Cloud Build definitions are included in the [exam
 | project\_labels | Labels to apply to the project. | `map(string)` | `{}` | no |
 | project\_prefix | Name prefix to use for projects created. | `string` | `"cft"` | no |
 | sa\_enable\_impersonation | Allow org\_admins group to impersonate service account & enable APIs required. | `bool` | `false` | no |
-| skip\_gcloud\_download | Whether to skip downloading gcloud (assumes gcloud is already available outside the module) | `bool` | `true` | no |
 | storage\_bucket\_labels | Labels to apply to the storage bucket. | `map(string)` | `{}` | no |
 | terraform\_apply\_branches | List of git branches configured to run terraform apply Cloud Build trigger. All other branches will run plan by default. | `list(string)` | <pre>[<br>  "master"<br>]</pre> | no |
 | terraform\_sa\_email | Email for terraform service account. | `string` | n/a | yes |
@@ -92,9 +91,8 @@ Functional examples and sample Cloud Build definitions are included in the [exam
 ### Software
 
 -   [gcloud sdk](https://cloud.google.com/sdk/install) >= 206.0.0
--   [Terraform](https://www.terraform.io/downloads.html) >= 0.12.20
--   [terraform-provider-google] plugin 2.1.x
--   [terraform-provider-google-beta] plugin 2.1.x
+-   [Terraform](https://www.terraform.io/downloads.html) >= 0.13.0
+-   [terraform-provider-google] plugin 3.50.x
 
 ### Permissions
 

--- a/modules/cloudbuild/main.tf
+++ b/modules/cloudbuild/main.tf
@@ -37,7 +37,7 @@ data "google_organization" "org" {
 
 module "cloudbuild_project" {
   source                      = "terraform-google-modules/project-factory/google"
-  version                     = "~> 9.2"
+  version                     = "~> 10.0.1"
   name                        = local.cloudbuild_project_id
   random_project_id           = true
   disable_services_on_destroy = false
@@ -46,7 +46,6 @@ module "cloudbuild_project" {
   billing_account             = var.billing_account
   activate_apis               = local.activate_apis
   labels                      = var.project_labels
-  skip_gcloud_download        = var.skip_gcloud_download
 }
 
 resource "google_project_service" "cloudbuild_apis" {

--- a/modules/cloudbuild/variables.tf
+++ b/modules/cloudbuild/variables.tf
@@ -149,12 +149,6 @@ variable "terraform_validator_release" {
   default     = "2020-09-24"
 }
 
-variable "skip_gcloud_download" {
-  description = "Whether to skip downloading gcloud (assumes gcloud is already available outside the module)"
-  type        = bool
-  default     = true
-}
-
 variable "cloudbuild_plan_filename" {
   description = "Path and name of Cloud Build YAML definition used for terraform plan."
   type        = string

--- a/modules/cloudbuild/versions.tf
+++ b/modules/cloudbuild/versions.tf
@@ -15,10 +15,16 @@
  */
 
 terraform {
-  required_version = ">=0.12.20"
+  required_version = ">=0.13.0"
 
   required_providers {
-    google      = "~> 3.5"
-    google-beta = "~> 3.5"
+    google = {
+      source  = "hashicorp/google"
+      version = ">= 3.50"
+    }
+  }
+
+  provider_meta "google" {
+    module_name = "blueprints/terraform/terraform-google-bootstrap:cloudbuild/v1.7.0"
   }
 }

--- a/test/setup/main.tf
+++ b/test/setup/main.tf
@@ -16,14 +16,13 @@
 
 module "project" {
   source  = "terraform-google-modules/project-factory/google"
-  version = "~> 9.2"
+  version = "~> 10.0.1"
 
-  name                 = "ci-bootstrap"
-  random_project_id    = true
-  org_id               = var.org_id
-  folder_id            = var.folder_id
-  billing_account      = var.billing_account
-  skip_gcloud_download = true
+  name              = "ci-bootstrap"
+  random_project_id = true
+  org_id            = var.org_id
+  folder_id         = var.folder_id
+  billing_account   = var.billing_account
 
   activate_apis = [
     "cloudresourcemanager.googleapis.com",

--- a/variables.tf
+++ b/variables.tf
@@ -146,9 +146,3 @@ variable "org_project_creators" {
   type        = list(string)
   default     = []
 }
-
-variable "skip_gcloud_download" {
-  description = "Whether to skip downloading gcloud (assumes gcloud is already available outside the module)"
-  type        = bool
-  default     = true
-}

--- a/versions.tf
+++ b/versions.tf
@@ -15,10 +15,16 @@
  */
 
 terraform {
-  required_version = ">=0.12.20"
+  required_version = ">=0.13.0"
 
   required_providers {
-    google      = "~> 3.9"
-    google-beta = "~> 3.9"
+    google = {
+      source  = "hashicorp/google"
+      version = ">= 3.50"
+    }
+  }
+
+  provider_meta "google" {
+    module_name = "blueprints/terraform/terraform-google-bootstrap:/v1.7.0"
   }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -25,6 +25,6 @@ terraform {
   }
 
   provider_meta "google" {
-    module_name = "blueprints/terraform/terraform-google-bootstrap:/v1.7.0"
+    module_name = "blueprints/terraform/terraform-google-bootstrap/v1.7.0"
   }
 }


### PR DESCRIPTION
This is required to support Terraform version 0.14. It is also a
breaking change because it dropped the `skip_gcloud_download` variable.