### PR TITLE
add cloudbuild bucket

### DIFF
--- a/modules/cloudbuild/main.tf
+++ b/modules/cloudbuild/main.tf
@@ -269,6 +269,15 @@ resource "google_storage_bucket_iam_member" "cloudbuild_artifacts_iam" {
   ]
 }
 
+resource "google_storage_bucket_iam_member" "cloudbuild_iam" {
+  bucket = google_storage_bucket.cloudbuild.name
+  role   = "roles/storage.admin"
+  member = "serviceAccount:${module.cloudbuild_project.project_number}@cloudbuild.gserviceaccount.com"
+  depends_on = [
+    google_project_service.cloudbuild_apis,
+  ]
+}
+
 resource "google_service_account_iam_member" "cloudbuild_terraform_sa_impersonate_permissions" {
   count = local.impersonation_enabled_count
 

--- a/modules/cloudbuild/main.tf
+++ b/modules/cloudbuild/main.tf
@@ -86,6 +86,14 @@ resource "google_storage_bucket" "cloudbuild_artifacts" {
   }
 }
 
+resource "google_storage_bucket" "cloudbuild" {
+  project                     = module.cloudbuild_project.project_id
+  name                        = format("%s_%s", module.cloudbuild_project.project_id, "cloudbuild")
+  location                    = var.default_region
+  labels                      = var.storage_bucket_labels
+  uniform_bucket_level_access = true
+}
+
 /******************************************
   KMS Keyring
  *****************************************/
@@ -244,6 +252,7 @@ resource "null_resource" "cloudbuild_terraform_builder" {
   }
   depends_on = [
     google_project_service.cloudbuild_apis,
+    google_storage_bucket.cloudbuild,
   ]
 }
 


### PR DESCRIPTION
This PR creates the cloud build bucket in the default region, because it not possible to run cloudbuild_terraform_builder with `constraints/gcp.resourceLocations` = `in:europe-west1-locations`

```module.cloudbuild_bootstrap.null_resource.cloudbuild_terraform_builder: Destroying... [id=2773361358890048467]
module.cloudbuild_bootstrap.null_resource.cloudbuild_terraform_builder: Destruction complete after 0s
google_organization_iam_member.org_cb_sa_browser[0]: Creating...
module.cloudbuild_bootstrap.null_resource.cloudbuild_terraform_builder: Creating...
module.cloudbuild_bootstrap.null_resource.cloudbuild_terraform_builder: Provisioning with 'local-exec'...
module.cloudbuild_bootstrap.null_resource.cloudbuild_terraform_builder (local-exec): Executing: ["/bin/sh" "-c" "      gcloud builds submit .terraform/modules/cloudbuild_bootstrap/modules/cloudbuild/cloudbuild_builder/ \\\n      --project prj-cloudbuild-a94e \\\n      --config=.terraform/modules/cloudbuild_bootstrap/modules/cloudbuild/cloudbuild_builder/cloudbuild.yaml \\\n      --substitutions=_TERRAFORM_VERSION=0.13.5,_TERRAFORM_VERSION_SHA256SUM=f7b7a7b1bfbf5d78151cfe3d1d463140b5fd6a354e71a7de2b5644e652ca5147,_TERRAFORM_VALIDATOR_RELEASE=2021-01-21\n"]
module.cloudbuild_bootstrap.null_resource.cloudbuild_terraform_builder (local-exec): ERROR: (gcloud.builds.submit) HTTPError 412: 'us' violates constraint 'constraints/gcp.resourceLocations'

google_organization_iam_member.org_cb_sa_browser[0]: Creation complete after 8s [id=813894941823/roles/browser/serviceaccount:969665253670@cloudbuild.gserviceaccount.com]

Error: Error running command '      gcloud builds submit .terraform/modules/cloudbuild_bootstrap/modules/cloudbuild/cloudbuild_builder/ \
      --project prj-cloudbuild-a94e \
      --config=.terraform/modules/cloudbuild_bootstrap/modules/cloudbuild/cloudbuild_builder/cloudbuild.yaml \
      --substitutions=_TERRAFORM_VERSION=0.13.5,_TERRAFORM_VERSION_SHA256SUM=f7b7a7b1bfbf5d78151cfe3d1d463140b5fd6a354e71a7de2b5644e652ca5147,_TERRAFORM_VALIDATOR_RELEASE=2021-01-21
': exit status 1. Output: ERROR: (gcloud.builds.submit) HTTPError 412: 'us' violates constraint 'constraints/gcp.resourceLocations'
```