### PR TITLE
fix: expose GAR repo name via substitutions in triggers

### DIFF
--- a/kitchen.yml
+++ b/kitchen.yml
@@ -16,6 +16,7 @@
 driver:
   name: terraform
   verify_version: false
+  command_timeout: 1200
 
 provisioner:
   name: terraform

--- a/modules/cloudbuild/main.tf
+++ b/modules/cloudbuild/main.tf
@@ -166,6 +166,7 @@ resource "google_cloudbuild_trigger" "master_trigger" {
     _ORG_ID               = var.org_id
     _BILLING_ID           = var.billing_account
     _DEFAULT_REGION       = var.default_region
+    _GAR_REPOSITORY       = local.gar_name
     _TF_SA_EMAIL          = var.terraform_sa_email
     _STATE_BUCKET_NAME    = var.terraform_state_bucket
     _ARTIFACT_BUCKET_NAME = google_storage_bucket.cloudbuild_artifacts.name
@@ -197,6 +198,7 @@ resource "google_cloudbuild_trigger" "non_master_trigger" {
     _ORG_ID               = var.org_id
     _BILLING_ID           = var.billing_account
     _DEFAULT_REGION       = var.default_region
+    _GAR_REPOSITORY       = local.gar_name
     _TF_SA_EMAIL          = var.terraform_sa_email
     _STATE_BUCKET_NAME    = var.terraform_state_bucket
     _ARTIFACT_BUCKET_NAME = google_storage_bucket.cloudbuild_artifacts.name


### PR DESCRIPTION
Adds GAR repo name via substitutions in triggers to for usage in builds like https://github.com/terraform-google-modules/terraform-example-foundation/blob/f87ed1661bec7c2d2c75ea091d1cf5db6ac6943a/build/cloudbuild-tf-apply.yaml#L20 