### PR TITLE
add support for multi_regional state bucket

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ For the cloudbuild submodule, see the README [cloudbuild](./modules/cloudbuild).
 | sa\_org\_iam\_permissions | List of permissions granted to Terraform service account across the GCP organization. | `list(string)` | <pre>[<br>  "roles/billing.user",<br>  "roles/compute.networkAdmin",<br>  "roles/compute.xpnAdmin",<br>  "roles/iam.securityAdmin",<br>  "roles/iam.serviceAccountAdmin",<br>  "roles/logging.configWriter",<br>  "roles/orgpolicy.policyAdmin",<br>  "roles/resourcemanager.folderAdmin",<br>  "roles/resourcemanager.organizationViewer"<br>]</pre> | no |
 | state\_bucket\_name | Custom state bucket name. If not supplied, the default name is {project\_prefix}-tfstate-{random suffix}. | `string` | `""` | no |
 | storage\_bucket\_labels | Labels to apply to the storage bucket. | `map(string)` | `{}` | no |
+| storage\_bucket\_location | The terraform state bucket location.  If not supplied then var.default\_region is used.  Warning - this can be a destructive change on the bucket. | `string` | `null` | no |
+| storage\_bucket\_storage\_class | The terraform state bucket storage class.  Used in combination with storage\_bucket\_location.  Warning - this can be a destructive change on the bucket. | `string` | `"STANDARD"` | no |
 
 ## Outputs
 

--- a/main.tf
+++ b/main.tf
@@ -17,6 +17,7 @@
 locals {
   seed_project_id             = var.project_id != "" ? var.project_id : format("%s-%s", var.project_prefix, "seed")
   state_bucket_name           = var.state_bucket_name != "" ? var.state_bucket_name : format("%s-%s-%s", var.project_prefix, "tfstate", random_id.suffix.hex)
+  storage_bucket_location     = var.storage_bucket_location != null ? var.storage_bucket_location : var.default_region
   impersonation_apis          = distinct(concat(var.activate_apis, ["serviceusage.googleapis.com", "iamcredentials.googleapis.com"]))
   impersonation_enabled_count = var.sa_enable_impersonation == true ? 1 : 0
   activate_apis               = var.sa_enable_impersonation == true ? local.impersonation_apis : var.activate_apis
@@ -82,8 +83,9 @@ resource "google_service_account" "org_terraform" {
 resource "google_storage_bucket" "org_terraform_state" {
   project                     = module.seed_project.project_id
   name                        = local.state_bucket_name
-  location                    = var.default_region
+  location                    = local.storage_bucket_location
   labels                      = var.storage_bucket_labels
+  storage_class               = var.storage_bucket_storage_class
   uniform_bucket_level_access = true
   versioning {
     enabled = true

--- a/variables.tf
+++ b/variables.tf
@@ -132,6 +132,18 @@ variable "storage_bucket_labels" {
   default     = {}
 }
 
+variable "storage_bucket_location" {
+  description = "The terraform state bucket location.  If not supplied then var.default_region is used.  Warning - this can be a destructive change on the bucket."
+  default     = null
+  type        = string
+}
+
+variable "storage_bucket_storage_class" {
+  description = "The terraform state bucket storage class.  Used in combination with storage_bucket_location.  Warning - this can be a destructive change on the bucket."
+  default     = "STANDARD"
+  type        = string
+}
+
 variable "org_admins_org_iam_permissions" {
   description = "List of permissions granted to the group supplied in group_org_admins variable across the GCP organization."
   type        = list(string)


### PR DESCRIPTION
Add support for multi_regional terraform state bucket.
Do so in a way that is non-disruptive for existing deployments.
Manually tested on terraform 0.13.6 and 0.14.7 against existing deployment and new deployments.