### PR TITLE
fix: Adds conditional logic to cloudbuild_builder to support Terraform Validator binary package format change

### DIFF
--- a/modules/cloudbuild/cloudbuild_builder/Dockerfile
+++ b/modules/cloudbuild/cloudbuild_builder/Dockerfile
@@ -32,7 +32,18 @@ RUN apt-get update && \
     sha256sum -c terraform_SHA256SUMS --status && \
     unzip terraform_linux_amd64.zip -d /builder/terraform && \
     rm -f terraform_linux_amd64.zip && \
-    gsutil cp gs://terraform-validator/releases/${ENV_TERRAFORM_VALIDATOR_RELEASE}/terraform-validator-linux-amd64 /builder/terraform/terraform-validator && \
+    VALIDATOR_RELEASE_VERSION=$(echo $ENV_TERRAFORM_VALIDATOR_RELEASE | sed -e 's/^v//') && \
+    VALIDATOR_RELEASE_NUMBER_AS_INT=$(echo $VALIDATOR_RELEASE_VERSION | sed -e 's/\.//g;s/^0//') && \
+    TARBALL_VERSION_THRESHOLD_AS_INT="60" && \
+    GCS_BASE_PATH="gs://terraform-validator/releases/${ENV_TERRAFORM_VALIDATOR_RELEASE}" && \
+    LEGACY_GCS_PATH="${GCS_BASE_PATH}/terraform-validator-linux-amd64" && \
+    CURRENT_GCS_PATH="${GCS_BASE_PATH}/terraform-validator_linux_amd64-${VALIDATOR_RELEASE_VERSION}.tar.gz" && \
+    if ( echo "$ENV_TERRAFORM_VALIDATOR_RELEASE" | grep -v '-' | grep -q '^v' ) && \
+    [ "$VALIDATOR_RELEASE_NUMBER_AS_INT" -ge "$TARBALL_VERSION_THRESHOLD_AS_INT" ]; then \
+      echo "Terraform Validator recent version >= v0.6.0 : zipped tarball"; gsutil cat ${CURRENT_GCS_PATH} | tar zxv -C /builder/terraform; \
+    else \
+      echo "Terraform Validator legacy version < v0.6.0"; gsutil cp ${LEGACY_GCS_PATH} /builder/terraform/terraform-validator; \
+    fi && \
     chmod +x /builder/terraform/terraform-validator && \
     apt-get --purge -y autoremove && \
     apt-get clean && \


### PR DESCRIPTION
- Fixes #117 
- Adds logic to `modules/cloudbuild/cloudbuild_builder/Dockerfile` to handle both legacy Terraform Validator binary package format as well as new binary package format (zipped tarball) and different package naming convention rolled out as of  `v0.6.0`
- Tested updated Dockerfile logic locally and in Cloud Shell with both `docker` and Cloud Build using a range of Terraform Validator versions e.g. `2021-03-22`,`v0.4.0`, `v0.6.0` and current `v0.7.0`.