### PR TITLE
fix: add a missing permission to run the test suite

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,7 +38,7 @@ submodules, and example modules are all functionally correct.
 ### Test Environment
 The easiest way to test the module is in an isolated test project. The setup for such a project is defined in [test/setup](./test/setup/) directory.
 
-To use this setup, you need a service account with Project Creator access on a folder. Export the Service Account credentials to your environment like so:
+To use this setup, you need a service account with Project Creator access on a folder and Billing Account User on the billing account. Export the Service Account credentials to your environment like so:
 
 ```
 export SERVICE_ACCOUNT_JSON=$(< credentials.json)


### PR DESCRIPTION
First run of the test suite raised the following error:

> Error: failed pre-requisites: missing permission on "billingAccounts/01F315-CB4CDA-094B5E": billing.resourceAssociations.create

I believe assigning billing account user role to the service account running the suite fixes this issue.