### PR TITLE
Guarantee the execution permission in the entrypoint.bash file

### DIFF
--- a/modules/cloudbuild/cloudbuild_builder/Dockerfile
+++ b/modules/cloudbuild/cloudbuild_builder/Dockerfile
@@ -23,6 +23,8 @@ ENV ENV_TERRAFORM_VERSION=$TERRAFORM_VERSION
 ENV ENV_TERRAFORM_VERSION_SHA256SUM=$TERRAFORM_VERSION_SHA256SUM
 ENV ENV_TERRAFORM_VALIDATOR_RELEASE=$TERRAFORM_VALIDATOR_RELEASE
 
+COPY entrypoint.bash /builder/entrypoint.bash
+
 RUN apt-get update && \
    /builder/google-cloud-sdk/bin/gcloud -q components install alpha beta && \
     apt-get -y install curl jq unzip git ca-certificates && \
@@ -41,8 +43,8 @@ RUN apt-get update && \
     rm -f "${TERRAFORM_VALIDATOR_ARCHIVE}" && \
     apt-get --purge -y autoremove && \
     apt-get clean && \
-    rm -rf /var/lib/apt/lists/*
+    rm -rf /var/lib/apt/lists/* && \
+    chmod +x /builder/entrypoint.bash
 
 ENV PATH=/builder/terraform/:$PATH
-COPY entrypoint.bash /builder/entrypoint.bash
 ENTRYPOINT ["/builder/entrypoint.bash"]


### PR DESCRIPTION
Add in the docker file a command to guarantee that the execute permission in the entrypoint.bash file is given even in a windows platform.

The terraform has a different behavior on Windows when dealing with the ZIP, the files contained has 666 permissions (no execute) for more information see issue [#58](https://github.com/hashicorp/terraform-provider-archive/issues/58) in the [terraform-provider-archive](https://github.com/hashicorp/terraform-provider-archive).