### PR TITLE
Allow service account impersonation in the local-exec gcloud runs.

### DIFF
--- a/modules/cloudbuild/README.md
+++ b/modules/cloudbuild/README.md
@@ -61,7 +61,7 @@ Functional examples and sample Cloud Build definitions are included in the [exam
 | folder\_id | The ID of a folder to host this project | `string` | `""` | no |
 | gar\_repo\_name | Custom name to use for GAR repo. | `string` | `""` | no |
 | group\_org\_admins | Google Group for GCP Organization Administrators | `string` | n/a | yes |
-| impersonate\_service\_account | The service account to run the gcloud command as | `string` | `""` | no |
+| impersonate\_service\_account | The service account to impersonate while running the gcloud builds submit command | `string` | `""` | no |
 | org\_id | GCP Organization ID | `string` | n/a | yes |
 | project\_id | Custom project ID to use for project created. | `string` | `""` | no |
 | project\_labels | Labels to apply to the project. | `map(string)` | `{}` | no |

--- a/modules/cloudbuild/README.md
+++ b/modules/cloudbuild/README.md
@@ -61,6 +61,7 @@ Functional examples and sample Cloud Build definitions are included in the [exam
 | folder\_id | The ID of a folder to host this project | `string` | `""` | no |
 | gar\_repo\_name | Custom name to use for GAR repo. | `string` | `""` | no |
 | group\_org\_admins | Google Group for GCP Organization Administrators | `string` | n/a | yes |
+| impersonate\_service\_account | The service account to run the gcloud command as | `string` | `""` | no |
 | org\_id | GCP Organization ID | `string` | n/a | yes |
 | project\_id | Custom project ID to use for project created. | `string` | `""` | no |
 | project\_labels | Labels to apply to the project. | `map(string)` | `{}` | no |

--- a/modules/cloudbuild/README.md
+++ b/modules/cloudbuild/README.md
@@ -61,7 +61,7 @@ Functional examples and sample Cloud Build definitions are included in the [exam
 | folder\_id | The ID of a folder to host this project | `string` | `""` | no |
 | gar\_repo\_name | Custom name to use for GAR repo. | `string` | `""` | no |
 | group\_org\_admins | Google Group for GCP Organization Administrators | `string` | n/a | yes |
-| impersonate\_service\_account | The service account to impersonate while running the gcloud builds submit command | `string` | `""` | no |
+| impersonate\_service\_account | The service account to impersonate while running the gcloud builds submit command. | `string` | `""` | no |
 | org\_id | GCP Organization ID | `string` | n/a | yes |
 | project\_id | Custom project ID to use for project created. | `string` | `""` | no |
 | project\_labels | Labels to apply to the project. | `map(string)` | `{}` | no |

--- a/modules/cloudbuild/main.tf
+++ b/modules/cloudbuild/main.tf
@@ -22,6 +22,7 @@ locals {
   activate_apis               = distinct(concat(var.activate_apis, local.cloudbuild_apis))
   apply_branches_regex        = "^(${join("|", var.terraform_apply_branches)})$"
   gar_name                    = split("/", google_artifact_registry_repository.tf-image-repo.name)[length(split("/", google_artifact_registry_repository.tf-image-repo.name)) - 1]
+  impersonate_service_account = var.impersonate_service_account != "" ? "--impersonate-service-account=${var.impersonate_service_account}" : ""
 }
 
 resource "random_id" "suffix" {
@@ -193,7 +194,7 @@ resource "null_resource" "cloudbuild_terraform_builder" {
 
   provisioner "local-exec" {
     command = <<EOT
-    gcloud --impersonate-service-account=${var.impersonate_service_account} builds submit ${path.module}/cloudbuild_builder/ --project ${module.cloudbuild_project.project_id} --config=${path.module}/cloudbuild_builder/cloudbuild.yaml --substitutions=_TERRAFORM_VERSION=${var.terraform_version},_TERRAFORM_VERSION_SHA256SUM=${var.terraform_version_sha256sum},_TERRAFORM_VALIDATOR_RELEASE=${var.terraform_validator_release},_REGION=${google_artifact_registry_repository.tf-image-repo.location},_REPOSITORY=${local.gar_name}
+    gcloud ${local.impersonate_service_account} builds submit ${path.module}/cloudbuild_builder/ --project ${module.cloudbuild_project.project_id} --config=${path.module}/cloudbuild_builder/cloudbuild.yaml --substitutions=_TERRAFORM_VERSION=${var.terraform_version},_TERRAFORM_VERSION_SHA256SUM=${var.terraform_version_sha256sum},_TERRAFORM_VALIDATOR_RELEASE=${var.terraform_validator_release},_REGION=${google_artifact_registry_repository.tf-image-repo.location},_REPOSITORY=${local.gar_name}
   EOT
   }
   depends_on = [

--- a/modules/cloudbuild/main.tf
+++ b/modules/cloudbuild/main.tf
@@ -193,7 +193,7 @@ resource "null_resource" "cloudbuild_terraform_builder" {
 
   provisioner "local-exec" {
     command = <<EOT
-      gcloud builds submit ${path.module}/cloudbuild_builder/ --project ${module.cloudbuild_project.project_id} --config=${path.module}/cloudbuild_builder/cloudbuild.yaml --substitutions=_TERRAFORM_VERSION=${var.terraform_version},_TERRAFORM_VERSION_SHA256SUM=${var.terraform_version_sha256sum},_TERRAFORM_VALIDATOR_RELEASE=${var.terraform_validator_release},_REGION=${google_artifact_registry_repository.tf-image-repo.location},_REPOSITORY=${local.gar_name}
+    gcloud --impersonate-service-account=${var.impersonate_service_account} builds submit ${path.module}/cloudbuild_builder/ --project ${module.cloudbuild_project.project_id} --config=${path.module}/cloudbuild_builder/cloudbuild.yaml --substitutions=_TERRAFORM_VERSION=${var.terraform_version},_TERRAFORM_VERSION_SHA256SUM=${var.terraform_version_sha256sum},_TERRAFORM_VALIDATOR_RELEASE=${var.terraform_validator_release},_REGION=${google_artifact_registry_repository.tf-image-repo.location},_REPOSITORY=${local.gar_name}
   EOT
   }
   depends_on = [

--- a/modules/cloudbuild/variables.tf
+++ b/modules/cloudbuild/variables.tf
@@ -187,3 +187,8 @@ variable "random_suffix" {
   default     = true
 }
 
+variable "impersonate_service_account" {
+  description = "The service account to run the gcloud command as"
+  type = string
+  default = ""
+}

--- a/modules/cloudbuild/variables.tf
+++ b/modules/cloudbuild/variables.tf
@@ -188,7 +188,7 @@ variable "random_suffix" {
 }
 
 variable "impersonate_service_account" {
-  description = "The service account to run the gcloud command as"
+  description = "The service account to impersonate while running the gcloud builds submit command"
   type        = string
   default     = ""
 }

--- a/modules/cloudbuild/variables.tf
+++ b/modules/cloudbuild/variables.tf
@@ -189,6 +189,6 @@ variable "random_suffix" {
 
 variable "impersonate_service_account" {
   description = "The service account to run the gcloud command as"
-  type = string
-  default = ""
+  type        = string
+  default     = ""
 }

--- a/modules/cloudbuild/variables.tf
+++ b/modules/cloudbuild/variables.tf
@@ -188,7 +188,7 @@ variable "random_suffix" {
 }
 
 variable "impersonate_service_account" {
-  description = "The service account to impersonate while running the gcloud builds submit command"
+  description = "The service account to impersonate while running the gcloud builds submit command."
   type        = string
   default     = ""
 }


### PR DESCRIPTION
When impersonating a service account in the google terraform provider, the background api calls are performed as that service account with one exception. There is one gcloud command being called locally where impersonation is not taken into account. This PR fixes that.