### PR TITLE
feat: add support for `included_files` and `ignored_files` of `google_cloudbuild_trigger`

### DIFF
--- a/modules/tf_cloudbuild_workspace/README.md
+++ b/modules/tf_cloudbuild_workspace/README.md
@@ -40,6 +40,8 @@ This module creates:
 | buckets\_force\_destroy | When deleting the bucket for storing CloudBuild logs/TF state, this boolean option will delete all contained objects. If false, Terraform will fail to delete buckets which contain objects. | `bool` | `false` | no |
 | cloudbuild\_apply\_filename | Optional Cloud Build YAML definition used for terraform apply. Defaults to using inline definition. | `string` | `null` | no |
 | cloudbuild\_env\_vars | Optional list of environment variables to be used in builds. List of strings of form KEY=VALUE expected. | `list(string)` | `[]` | no |
+| cloudbuild\_ignored\_files | Optional list. Changes only affecting ignored files will not invoke a build. | `list(string)` | `[]` | no |
+| cloudbuild\_included\_files | Optional list. Changes affecting at least one of these files will invoke a build. | `list(string)` | `[]` | no |
 | cloudbuild\_plan\_filename | Optional Cloud Build YAML definition used for terraform plan. Defaults to using inline definition. | `string` | `null` | no |
 | cloudbuild\_sa | Custom SA id of form projects/{{project}}/serviceAccounts/{{email}} to be used by the CloudBuild trigger. Defaults to being created if empty. | `string` | `""` | no |
 | cloudbuild\_sa\_roles | Optional to assign to custom CloudBuild SA. Map of project name or any static key to object with project\_id and list of roles. | <pre>map(object({<br>    project_id = string<br>    roles      = list(string)<br>  }))</pre> | `{}` | no |

--- a/modules/tf_cloudbuild_workspace/cb.tf
+++ b/modules/tf_cloudbuild_workspace/cb.tf
@@ -138,6 +138,8 @@ resource "google_cloudbuild_trigger" "triggers" {
   substitutions   = merge(local.default_subst, var.substitutions)
   service_account = local.cloudbuild_sa
   filename        = local.default_triggers_explicit[each.key]
+  included_files  = var.cloudbuild_included_files
+  ignored_files   = var.cloudbuild_ignored_files
 
   depends_on = [
     google_project_iam_member.cb_sa_roles

--- a/modules/tf_cloudbuild_workspace/variables.tf
+++ b/modules/tf_cloudbuild_workspace/variables.tf
@@ -82,6 +82,18 @@ variable "cloudbuild_env_vars" {
   default     = []
 }
 
+variable "cloudbuild_included_files" {
+  description = "Optional list. Changes affecting at least one of these files will invoke a build."
+  type        = list(string)
+  default     = []
+}
+
+variable "cloudbuild_ignored_files" {
+  description = "Optional list. Changes only affecting ignored files will not invoke a build."
+  type        = list(string)
+  default     = []
+}
+
 variable "buckets_force_destroy" {
   description = "When deleting the bucket for storing CloudBuild logs/TF state, this boolean option will delete all contained objects. If false, Terraform will fail to delete buckets which contain objects."
   type        = bool


### PR DESCRIPTION
This PR adds support two options of `google_cloudbuild_trigger` resource.
- [`included_files`](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/cloudbuild_trigger#included_files)
- [`ignored_files`](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/cloudbuild_trigger#ignored_files)