### PR TITLE
feat: Add custom bucket names support for modules `tf_cloudbuild_workspace` and `tf_cloudbuild_builder`

### DIFF
--- a/modules/tf_cloudbuild_builder/README.md
+++ b/modules/tf_cloudbuild_builder/README.md
@@ -33,6 +33,7 @@ This module creates:
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| bucket\_name | Custom bucket name for Cloud Build logs. | `string` | `""` | no |
 | cb\_logs\_bucket\_force\_destroy | When deleting the bucket for storing CloudBuild logs, this boolean option will delete all contained objects. If false, Terraform will fail to delete buckets which contain objects. | `bool` | `false` | no |
 | cloudbuild\_sa | Custom SA email to be used by the CloudBuild trigger. Defaults to being created if empty. | `string` | `""` | no |
 | dockerfile\_repo\_dir | The directory inside the repo where the Dockerfile is located. If empty defaults to repo root. | `string` | `""` | no |

--- a/modules/tf_cloudbuild_builder/cb.tf
+++ b/modules/tf_cloudbuild_builder/cb.tf
@@ -22,6 +22,7 @@ locals {
   tf_full_version     = var.terraform_version
   tf_minor_version    = "${local.tf_version_parts[0]}.${local.tf_version_parts[1]}"
   tf_major_version    = local.tf_version_parts[0]
+  log_bucket_name     = var.bucket_name != "" ? var.bucket_name : "tf-cloudbuilder-build-logs-${var.project_id}"
 
   # substitutions available in the CB trigger
   tags_subst = {
@@ -105,7 +106,7 @@ module "bucket" {
   source  = "terraform-google-modules/cloud-storage/google//modules/simple_bucket"
   version = "~> 3.2"
 
-  name          = "tf-cloudbuilder-build-logs-${var.project_id}"
+  name          = local.log_bucket_name
   project_id    = var.project_id
   location      = var.gar_repo_location
   force_destroy = var.cb_logs_bucket_force_destroy

--- a/modules/tf_cloudbuild_builder/variables.tf
+++ b/modules/tf_cloudbuild_builder/variables.tf
@@ -128,3 +128,8 @@ variable "worker_pool_id" {
   default     = ""
 }
 
+variable "bucket_name" {
+  description = "Custom bucket name for Cloud Build logs."
+  type        = string
+  default     = ""
+}

--- a/modules/tf_cloudbuild_workspace/README.md
+++ b/modules/tf_cloudbuild_workspace/README.md
@@ -37,6 +37,7 @@ This module creates:
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| artifacts\_bucket\_name | Custom bucket name for Cloud Build artifacts. | `string` | `""` | no |
 | buckets\_force\_destroy | When deleting the bucket for storing CloudBuild logs/TF state, this boolean option will delete all contained objects. If false, Terraform will fail to delete buckets which contain objects. | `bool` | `false` | no |
 | cloudbuild\_apply\_filename | Optional Cloud Build YAML definition used for terraform apply. Defaults to using inline definition. | `string` | `null` | no |
 | cloudbuild\_env\_vars | Optional list of environment variables to be used in builds. List of strings of form KEY=VALUE expected. | `list(string)` | `[]` | no |
@@ -50,6 +51,7 @@ This module creates:
 | diff\_sa\_project | Set to true if `cloudbuild_sa` is in a different project for setting up https://cloud.google.com/build/docs/securing-builds/configure-user-specified-service-accounts#cross-project_set_up. | `bool` | `false` | no |
 | enable\_worker\_pool | Set to true to use a private worker pool in the Cloud Build Trigger. | `bool` | `false` | no |
 | location | Location for build logs/state bucket | `string` | `"us-central1"` | no |
+| log\_bucket\_name | Custom bucket name for Cloud Build logs. | `string` | `""` | no |
 | prefix | Prefix of the state/log buckets and triggers planning/applying config. If unset computes a prefix from tf\_repo\_uri and tf\_repo\_dir variables. | `string` | `""` | no |
 | project\_id | GCP project for Cloud Build triggers, state and log buckets. | `string` | n/a | yes |
 | state\_bucket\_self\_link | Custom GCS bucket for storing TF state. Defaults to being created if empty. | `string` | `""` | no |

--- a/modules/tf_cloudbuild_workspace/buckets.tf
+++ b/modules/tf_cloudbuild_workspace/buckets.tf
@@ -31,7 +31,7 @@ module "artifacts_bucket" {
   source  = "terraform-google-modules/cloud-storage/google//modules/simple_bucket"
   version = "~> 3.2"
 
-  name          = "${local.default_prefix}-build-artifacts-${var.project_id}"
+  name          = var.artifacts_bucket_name != "" ? var.artifacts_bucket_name : "${local.default_prefix}-build-artifacts-${var.project_id}"
   project_id    = var.project_id
   location      = var.location
   force_destroy = var.buckets_force_destroy
@@ -47,7 +47,7 @@ module "log_bucket" {
   source  = "terraform-google-modules/cloud-storage/google//modules/simple_bucket"
   version = "~> 3.2"
 
-  name          = "${local.default_prefix}-build-logs-${var.project_id}"
+  name          = var.log_bucket_name != "" ? var.log_bucket_name : "${local.default_prefix}-build-logs-${var.project_id}"
   project_id    = var.project_id
   location      = var.location
   force_destroy = var.buckets_force_destroy

--- a/modules/tf_cloudbuild_workspace/variables.tf
+++ b/modules/tf_cloudbuild_workspace/variables.tf
@@ -61,6 +61,18 @@ variable "state_bucket_self_link" {
   default     = ""
 }
 
+variable "log_bucket_name" {
+  description = "Custom bucket name for Cloud Build logs."
+  type        = string
+  default     = ""
+}
+
+variable "artifacts_bucket_name" {
+  description = "Custom bucket name for Cloud Build artifacts."
+  type        = string
+  default     = ""
+}
+
 variable "cloudbuild_sa_roles" {
   description = "Optional to assign to custom CloudBuild SA. Map of project name or any static key to object with project_id and list of roles."
   type = map(object({


### PR DESCRIPTION
Add custom bucket names support for automatically created buckets:
- module `tf_cloudbuild_workspace`
  - log_bucket
  - artifacts_bucket
- module `tf_cloudbuild_builder`
  - log_bucket