### PR TITLE
feat: add support for `approval_config` only for the "xxx-apply" trigger

### DIFF
--- a/modules/tf_cloudbuild_workspace/README.md
+++ b/modules/tf_cloudbuild_workspace/README.md
@@ -40,6 +40,7 @@ This module creates:
 | artifacts\_bucket\_name | Custom bucket name for Cloud Build artifacts. | `string` | `""` | no |
 | buckets\_force\_destroy | When deleting the bucket for storing CloudBuild logs/TF state, this boolean option will delete all contained objects. If false, Terraform will fail to delete buckets which contain objects. | `bool` | `false` | no |
 | cloudbuild\_apply\_filename | Optional Cloud Build YAML definition used for terraform apply. Defaults to using inline definition. | `string` | `null` | no |
+| cloudbuild\_apply\_manual\_approval | This is only for the 'xxx-apply' trigger. If this is set on a build, it will become pending when it is run, and will need to be explicitly approved to start. | `bool` | `false` | no |
 | cloudbuild\_env\_vars | Optional list of environment variables to be used in builds. List of strings of form KEY=VALUE expected. | `list(string)` | `[]` | no |
 | cloudbuild\_ignored\_files | Optional list. Changes only affecting ignored files will not invoke a build. | `list(string)` | `[]` | no |
 | cloudbuild\_included\_files | Optional list. Changes affecting at least one of these files will invoke a build. | `list(string)` | `[]` | no |

--- a/modules/tf_cloudbuild_workspace/cb.tf
+++ b/modules/tf_cloudbuild_workspace/cb.tf
@@ -131,6 +131,14 @@ resource "google_cloudbuild_trigger" "triggers" {
     }
   }
 
+  # approval_config
+  dynamic "approval_config" {
+    for_each = each.key == "apply" && var.cloudbuild_apply_manual_approval ? [1] : []
+    content {
+      approval_required = var.cloudbuild_apply_manual_approval
+    }
+  }
+
   substitutions   = merge(local.default_subst, var.substitutions)
   service_account = local.cloudbuild_sa
   filename        = local.default_triggers_explicit[each.key]

--- a/modules/tf_cloudbuild_workspace/variables.tf
+++ b/modules/tf_cloudbuild_workspace/variables.tf
@@ -124,6 +124,12 @@ variable "cloudbuild_ignored_files" {
   default     = []
 }
 
+variable "cloudbuild_apply_manual_approval" {
+  description = "This is only for the 'xxx-apply' trigger. If this is set on a build, it will become pending when it is run, and will need to be explicitly approved to start."
+  type        = bool
+  default     = false
+}
+
 variable "buckets_force_destroy" {
   description = "When deleting the bucket for storing CloudBuild logs/TF state, this boolean option will delete all contained objects. If false, Terraform will fail to delete buckets which contain objects."
   type        = bool


### PR DESCRIPTION
This PR adds support a option of google_cloudbuild_trigger resource only for the "xxx-apply" trigger.
- [`approval_config.approval_required`](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/cloudbuild_trigger#approval_config)

related: https://github.com/terraform-google-modules/terraform-google-bootstrap/issues/123