### PR TITLE
feat: add support for `cloudbuild_timeout` for `google_cloudbuild_builder`

### DIFF
--- a/modules/tf_cloudbuild_builder/README.md
+++ b/modules/tf_cloudbuild_builder/README.md
@@ -36,6 +36,7 @@ This module creates:
 | bucket\_name | Custom bucket name for Cloud Build logs. | `string` | `""` | no |
 | cb\_logs\_bucket\_force\_destroy | When deleting the bucket for storing CloudBuild logs, this boolean option will delete all contained objects. If false, Terraform will fail to delete buckets which contain objects. | `bool` | `false` | no |
 | cloudbuild\_sa | Custom SA email to be used by the CloudBuild trigger. Defaults to being created if empty. | `string` | `""` | no |
+| cloudbuild\_timeout | Custom timeout to be used by the CloudBuild trigger. Defaults to 10 minutes. | `string` | `"600s"` | no |
 | dockerfile\_repo\_dir | The directory inside the repo where the Dockerfile is located. If empty defaults to repo root. | `string` | `""` | no |
 | dockerfile\_repo\_ref | The branch or tag to use. Use refs/heads/branchname for branches or refs/tags/tagname for tags. | `string` | `"refs/heads/main"` | no |
 | dockerfile\_repo\_type | Type of repo | `string` | `"CLOUD_SOURCE_REPOSITORIES"` | no |

--- a/modules/tf_cloudbuild_builder/cb.tf
+++ b/modules/tf_cloudbuild_builder/cb.tf
@@ -66,6 +66,7 @@ resource "google_cloudbuild_trigger" "build_trigger" {
       name = "${local.gar_uri}:v$${_TERRAFORM_FULL_VERSION}"
       args = ["version"]
     }
+    timeout     = var.cloudbuild_timeout
     images      = local.img_tags_subst
     logs_bucket = module.bucket.bucket.url
 

--- a/modules/tf_cloudbuild_builder/variables.tf
+++ b/modules/tf_cloudbuild_builder/variables.tf
@@ -49,6 +49,12 @@ variable "cloudbuild_sa" {
   default     = ""
 }
 
+variable "cloudbuild_timeout" {
+  description = "Custom timeout to be used by the CloudBuild trigger. Defaults to 10 minutes."
+  type        = string
+  default     = "600s"
+}
+
 variable "cb_logs_bucket_force_destroy" {
   description = "When deleting the bucket for storing CloudBuild logs, this boolean option will delete all contained objects. If false, Terraform will fail to delete buckets which contain objects."
   type        = bool


### PR DESCRIPTION
Default timeout of 10 min is not enough to build the `tf-cloud-builder-build` of [terraform-example-foundation](https://github.com/terraform-google-modules/terraform-example-foundation/). Here's an example implementation that allows for to configure the timeout as a variable.