### PR TITLE
chore: Randomize repository names

### DIFF
--- a/modules/im_cloudbuild_workspace/cb.tf
+++ b/modules/im_cloudbuild_workspace/cb.tf
@@ -62,7 +62,7 @@ resource "google_cloudbuild_trigger" "triggers" {
 
   project            = var.project_id
   location           = var.trigger_location
-  name               = "im-${random_id.resources_random_id.dec}-${local.default_prefix}-${each.key}"
+  name               = substr("im-${each.key}-${random_id.resources_random_id.dec}-${local.default_prefix}", 0, 64)
   description        = "${title(each.key)} Terraform configs for ${var.im_deployment_repo_uri} ${var.im_deployment_repo_dir}"
   include_build_logs = local.is_gh_repo ? "INCLUDE_BUILD_LOGS_WITH_STATUS" : null
 

--- a/test/integration/im_cloudbuild_workspace_github/im_cloudbuild_workspace_github_test.go
+++ b/test/integration/im_cloudbuild_workspace_github/im_cloudbuild_workspace_github_test.go
@@ -139,7 +139,7 @@ func TestIMCloudBuildWorkspaceGitHub(t *testing.T) {
 	ctx := context.Background()
 
 	githubPAT := utils.ValFromEnv(t, "IM_GITHUB_PAT")
-	client := NewGitHubClient(t, githubPAT, "im-goose", "im-blueprint-test")
+	client := NewGitHubClient(t, githubPAT, "im-goose", fmt.Sprintf("im-blueprint-test-%s", getSetupRandomString(t)))
 
 	repo := client.GetRepository(ctx)
 	if repo == nil {
@@ -281,4 +281,10 @@ func getTerraformExample(t *testing.T) []byte {
 		t.Fatal(err.Error())
 	}
 	return contents
+}
+
+func getSetupRandomString(t *testing.T) string {
+	t.Helper()
+	setup := tft.NewTFBlueprintTest(t)
+	return setup.GetTFSetupStringOutput("random_testing_string")
 }

--- a/test/setup/outputs.tf
+++ b/test/setup/outputs.tf
@@ -54,3 +54,8 @@ output "default_region" {
 output "org_project_creators" {
   value = ["serviceAccount:${google_service_account.int_test.email}"]
 }
+
+output "random_testing_string" {
+  description = "Access the random ID created in setup for labeling other resources."
+  value       = random_id.suffix.hex
+}


### PR DESCRIPTION
Utilizes the random string present from setup. Also adjusted some resource name to reinforce string lengths based on the new repo name.