### PR TITLE
fix: Update check existing deployments command

### DIFF
--- a/modules/im_cloudbuild_workspace/templates/create-preview.sh.tftpl
+++ b/modules/im_cloudbuild_workspace/templates/create-preview.sh.tftpl
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 echo "Checking if deployment ${deployment_id} already exists"
-DEPLOYMENT_EXISTS=$(gcloud infra-manager deployments describe projects/${project_id}/locations/${location}/deployments/${deployment_id} | tail -n +2 | wc -l)
+DEPLOYMENT_EXISTS=$(gcloud infra-manager deployments list --location ${location} --filter ${deployment_id} | tail -n +2 | wc -l)
 
 echo "Deleting previous preview if it already exists"
 gcloud infra-manager previews delete projects/${project_id}/locations/${location}/previews/preview-$SHORT_SHA --quiet


### PR DESCRIPTION
Change the `gcloud` command to list the deployments filtered by the given ID. Should correctly match up with an existing deployment.