### PR TITLE
feat: Add tf_version variable for Infra Manager module

### DIFF
--- a/examples/im_cloudbuild_workspace_github/main.tf
+++ b/examples/im_cloudbuild_workspace_github/main.tf
@@ -25,11 +25,10 @@ module "im_workspace" {
   im_deployment_ref      = "main"
   im_tf_variables        = "project_id=${var.project_id}"
   infra_manager_sa_roles = ["roles/compute.networkAdmin"]
-  tf_cloudbuilder        = "hashicorp/terraform:1.2.3"
+  tf_version             = "1.2.3"
 
   // Found in the URL of your Cloud Build GitHub app configuration settings
   // https://cloud.google.com/build/docs/automating-builds/github/connect-repo-github?generation=2nd-gen#connecting_a_github_host_programmatically
-  github_app_installation_id = "47590865"
-
+  github_app_installation_id   = "47590865"
   github_personal_access_token = var.im_github_pat
 }

--- a/modules/im_cloudbuild_workspace/README.md
+++ b/modules/im_cloudbuild_workspace/README.md
@@ -68,8 +68,9 @@ for actuating resources.
 | pull\_request\_comment\_control | Configure builds to run whether a repository owner or collaborator needs to comment /gcbrun. | `string` | `"COMMENTS_ENABLED_FOR_EXTERNAL_CONTRIBUTORS_ONLY"` | no |
 | repo\_connection\_name | Connection name for linked repository. Generated if not given. | `string` | `""` | no |
 | substitutions | Optional map of substitutions to use in builds if using a custom Cloud Build YAML definition. | `map(string)` | `{}` | no |
-| tf\_cloudbuilder | Name of the Cloud Builder image used for running build steps. | `string` | `"hashicorp/terraform:1.5.7"` | no |
+| tf\_cloudbuilder | Name of the Cloud Builder image used for running build steps. | `string` | `"hashicorp/terraform"` | no |
 | tf\_repo\_type | Type of repo | `string` | `"GITHUB"` | no |
+| tf\_version | Terraform version to use for Infrastructure Manager and the Cloud Builder image. | `string` | `"1.2.3"` | no |
 | trigger\_location | Location of for Cloud Build triggers created in the workspace. Matches `location` if not given. | `string` | `"us-central1"` | no |
 
 ## Outputs

--- a/modules/im_cloudbuild_workspace/variables.tf
+++ b/modules/im_cloudbuild_workspace/variables.tf
@@ -130,10 +130,16 @@ variable "cloudbuild_ignored_files" {
   default     = []
 }
 
+variable "tf_version" {
+  description = "Terraform version to use for Infrastructure Manager and the Cloud Builder image."
+  type        = string
+  default     = "1.2.3"
+}
+
 variable "tf_cloudbuilder" {
   description = "Name of the Cloud Builder image used for running build steps."
   type        = string
-  default     = "hashicorp/terraform:1.5.7"
+  default     = "hashicorp/terraform"
 }
 
 variable "tf_repo_type" {


### PR DESCRIPTION
Adds the `tf_version` variable which is used to pass to Infrastructure Manager and appending to the TF image provided.

Also added some Cleanup methods to the verify and teardown steps to close the pull request and delete the repository.
Tested locally by just running a gcloud command with some gibberish to trigger a fatal test error.