### PR TITLE
feat: Add the ".git" suffix to the repo URL if missing

### DIFF
--- a/modules/im_cloudbuild_workspace/cb.tf
+++ b/modules/im_cloudbuild_workspace/cb.tf
@@ -22,7 +22,7 @@ locals {
     location        = var.location
     deployment_id   = var.deployment_id
     service_account = local.im_sa
-    source_repo     = var.im_deployment_repo_uri
+    source_repo     = local.repoURL
     source_repo_dir = var.im_deployment_repo_dir
     tf_vars         = var.im_tf_variables
   })
@@ -45,7 +45,7 @@ locals {
         "apply",
         "projects/${var.project_id}/locations/${var.location}/deployments/${var.deployment_id}",
         "--service-account=${local.im_sa}",
-        "--git-source-repo=${var.im_deployment_repo_uri}",
+        "--git-source-repo=${local.repoURL}",
         var.im_deployment_repo_dir != "" ? "--git-source-directory=${var.im_deployment_repo_dir}" : "",
         var.im_deployment_ref != "" ? "--git-source-ref=${var.im_deployment_ref}" : "",
         var.im_tf_variables != "" ? "--input-values=${var.im_tf_variables}" : "",
@@ -66,7 +66,7 @@ resource "google_cloudbuild_trigger" "triggers" {
   project            = var.project_id
   location           = var.trigger_location
   name               = substr("im-${each.key}-${random_id.resources_random_id.dec}-${local.default_prefix}", 0, 64)
-  description        = "${title(each.key)} Terraform configs for ${var.im_deployment_repo_uri} ${var.im_deployment_repo_dir}"
+  description        = "${title(each.key)} Terraform configs for ${local.repoURL} ${var.im_deployment_repo_dir}"
   include_build_logs = local.is_gh_repo ? "INCLUDE_BUILD_LOGS_WITH_STATUS" : null
 
   repository_event_config {

--- a/modules/im_cloudbuild_workspace/github.tf
+++ b/modules/im_cloudbuild_workspace/github.tf
@@ -17,7 +17,7 @@
 locals {
   # GitHub repo url of form "github.com/owner/name"
   is_gh_repo        = var.tf_repo_type == "GITHUB"
-  gh_repo_url_split = local.is_gh_repo ? split("/", local.url) : []
+  gh_repo_url_split = local.is_gh_repo ? split("/", local.repoURLWithoutSuffix) : []
   gh_name           = local.is_gh_repo ? local.gh_repo_url_split[length(local.gh_repo_url_split) - 1] : ""
 
   create_github_secret           = local.is_gh_repo && var.github_personal_access_token != ""

--- a/modules/im_cloudbuild_workspace/gitlab.tf
+++ b/modules/im_cloudbuild_workspace/gitlab.tf
@@ -17,7 +17,7 @@
 locals {
   # GitLab repo url of form "[host_uri]/[owners]/project"
   is_gl_repo        = var.tf_repo_type == "GITLAB"
-  gl_repo_url_split = local.is_gl_repo ? split("/", local.url) : []
+  gl_repo_url_split = local.is_gl_repo ? split("/", local.repoURLWithoutSuffix) : []
   gl_project        = local.is_gl_repo ? local.gl_repo_url_split[length(local.gl_repo_url_split) - 1] : ""
 
   create_api_secret           = local.is_gl_repo && var.gitlab_api_access_token != ""

--- a/modules/im_cloudbuild_workspace/repo.tf
+++ b/modules/im_cloudbuild_workspace/repo.tf
@@ -16,7 +16,7 @@
 
 locals {
   repoURL = endswith(var.im_deployment_repo_uri, ".git") ? var.im_deployment_repo_uri : "${var.im_deployment_repo_uri}.git"
-  # Remove the ".git" suffix for parsing the url for owner/repo 
+  // Remove the ".git" suffix for parsing the url for owner/repo
   repoURLWithoutSuffix = trimsuffix(local.repoURL, ".git")
 
   repo           = local.is_gh_repo ? local.gh_name : local.gl_project

--- a/modules/im_cloudbuild_workspace/repo.tf
+++ b/modules/im_cloudbuild_workspace/repo.tf
@@ -15,8 +15,9 @@
  */
 
 locals {
-  # Remove ".git" suffix if it's included
-  url = trimsuffix(var.im_deployment_repo_uri, ".git")
+  repoURL = endswith(var.im_deployment_repo_uri, ".git") ? var.im_deployment_repo_uri : "${var.im_deployment_repo_uri}.git"
+  # Remove the ".git" suffix for parsing the url for owner/repo 
+  repoURLWithoutSuffix = trimsuffix(local.repoURL, ".git")
 
   repo           = local.is_gh_repo ? local.gh_name : local.gl_project
   default_prefix = local.repo
@@ -72,5 +73,5 @@ resource "google_cloudbuildv2_repository" "repository_connection" {
   location          = var.location
   name              = local.repo_connection_name
   parent_connection = google_cloudbuildv2_connection.vcs_connection.name
-  remote_uri        = var.im_deployment_repo_uri
+  remote_uri        = local.repoURL
 }

--- a/test/integration/im_cloudbuild_workspace_github/im_cloudbuild_workspace_github_test.go
+++ b/test/integration/im_cloudbuild_workspace_github/im_cloudbuild_workspace_github_test.go
@@ -148,9 +148,11 @@ func TestIMCloudBuildWorkspaceGitHub(t *testing.T) {
 		client.AddFileToRepository(ctx, utils.GetFileContents(t, "files/main.tf"))
 	}
 
+	// Testing the module's feature of appending the ".git" suffix if it's missing
+	repoURL := strings.TrimSuffix(client.repository.GetCloneURL(), ".git")
 	vars := map[string]interface{}{
 		"im_github_pat":  githubPAT,
-		"repository_url": client.repository.GetCloneURL(),
+		"repository_url": repoURL,
 	}
 	bpt := tft.NewTFBlueprintTest(t, tft.WithVars(vars))
 


### PR DESCRIPTION
Cloud Build requires the suffix in order to create a connection, so we can just add it if it isn't given.

Updated the GitHub test to strip the ".git" suffix of the CloneURL to test the behavior.