### PR TITLE
feat: Set project field on secret IAM member

### DIFF
--- a/modules/im_cloudbuild_workspace/github.tf
+++ b/modules/im_cloudbuild_workspace/github.tf
@@ -64,6 +64,7 @@ data "google_secret_manager_secret_version" "existing_github_pat_secret_version"
 
 resource "google_secret_manager_secret_iam_member" "github_token_iam_member" {
   count     = local.is_gh_repo ? 1 : 0
+  project   = var.project_id
   secret_id = local.github_secret_id
   role      = "roles/secretmanager.secretAccessor"
   member    = "serviceAccount:service-${data.google_project.project.number}@gcp-sa-cloudbuild.iam.gserviceaccount.com"

--- a/modules/im_cloudbuild_workspace/gitlab.tf
+++ b/modules/im_cloudbuild_workspace/gitlab.tf
@@ -122,6 +122,7 @@ data "google_secret_manager_secret_version" "existing_gitlab_read_api_secret_ver
 
 resource "google_secret_manager_secret_iam_member" "gitlab_secret_members" {
   for_each  = local.is_gl_repo ? { "api" = local.api_secret_id, "read_api" = local.read_api_secret_id, "webhook" = google_secret_manager_secret.gitlab_webhook_secret[0].id } : {}
+  project   = var.project_id
   secret_id = each.value
   role      = "roles/secretmanager.secretAccessor"
   member    = "serviceAccount:service-${data.google_project.project.number}@gcp-sa-cloudbuild.iam.gserviceaccount.com"


### PR DESCRIPTION
Need to explicitly set which project is being used for the secret, otherwise it may not be able to determine which project to use.

Explicit tests are a little tricky to write because each bootstrapped project using in testing would need access to the secret. Open to doing that, but not sure the scope of changes needed for that (possibly at the CFT level).