### PR TITLE
fix(race): KMS module can create resources too early

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -130,6 +130,11 @@ module "kms" {
     "serviceAccount:${data.google_storage_project_service_account.gcs_account.email_address}",
   ]
   prevent_destroy = var.kms_prevent_destroy
+
+  depends_on = [
+    # To avoid a race-condition on google service API activation (which sets up the google storage project service-account), depend on the seed project.
+    module.seed_project,
+  ]
 }
 
 resource "google_storage_bucket" "org_terraform_state" {


### PR DESCRIPTION
With `TF_PARALLELISM=80` when applying the tech-foundations bootstrap ([ref](https://github.com/terraform-google-modules/terraform-example-foundation/blob/main/0-bootstrap/main.tf)), it's possible to get an error.

This can occur because the `data.google_storage_project_service_account` does not exist yet (it is provisioned by the `google_project_service` in the project-factory module - https://github.com/terraform-google-modules/terraform-google-project-factory/blob/main/modules/project_services/main.tf#L31-L37)

```console
╷
│ Error: Error applying IAM policy for KMS CryptoKey "projects/prj-b-seed-7128/locations/us-central1/keyRings/prj-keyring/cryptoKeys/prj-key": Error setting IAM policy for KMS CryptoKey "projects/prj-b-seed-7128/locations/us-central1/keyRings/prj-keyring/cryptoKeys/prj-key": googleapi: Error 400: Service account service-224653906387@gs-project-accounts.iam.gserviceaccount.com does not exist., badRequest
│
│   with module.seed_bootstrap.module.kms[0].google_kms_crypto_key_iam_binding.encrypters[0],
│   on .terraform/modules/seed_bootstrap.kms/main.tf line 89, in resource "google_kms_crypto_key_iam_binding" "encrypters":
│   89: resource "google_kms_crypto_key_iam_binding" "encrypters" {
│
╵
```