### PR TITLE
fix: Switch IM Cloud Build GitHub module test user

### DIFF
--- a/examples/im_cloudbuild_workspace_github/main.tf
+++ b/examples/im_cloudbuild_workspace_github/main.tf
@@ -30,6 +30,6 @@ module "im_workspace" {
 
   // Found in the URL of your Cloud Build GitHub app configuration settings
   // https://cloud.google.com/build/docs/automating-builds/github/connect-repo-github?generation=2nd-gen#connecting_a_github_host_programmatically
-  github_app_installation_id   = "47590865"
+  github_app_installation_id   = "68754904"
   github_personal_access_token = var.im_github_pat
 }

--- a/test/integration/im_cloudbuild_workspace_github/im_cloudbuild_workspace_github_test.go
+++ b/test/integration/im_cloudbuild_workspace_github/im_cloudbuild_workspace_github_test.go
@@ -31,6 +31,11 @@ import (
 	"github.com/terraform-google-modules/terraform-google-bootstrap/test/integration/utils"
 )
 
+const (
+	githubOwner = "infra-manager-bootstrap-module"
+	githubRepo  = "im-cloudbuild-workspace-github"
+)
+
 type GitHubClient struct {
 	t          *testing.T
 	client     *github.Client
@@ -104,49 +109,11 @@ func (gh *GitHubClient) GetRepository(ctx context.Context) *github.Repository {
 	return repo
 }
 
-func (gh *GitHubClient) CreateRepository(ctx context.Context, org, repoName string) *github.Repository {
-	newRepo := &github.Repository{
-		Name:       github.String(repoName),
-		AutoInit:   github.Bool(true),
-		Visibility: github.String("private"),
-	}
-	repo, _, err := gh.client.Repositories.Create(ctx, org, newRepo)
-	if err != nil {
-		gh.t.Fatal(err.Error())
-	}
-	gh.repository = repo
-	return repo
-}
-
-func (gh *GitHubClient) AddFileToRepository(ctx context.Context, file []byte) {
-	opts := &github.RepositoryContentFileOptions{
-		Content: file,
-		Message: github.String("Setup commit"),
-	}
-	_, _, err := gh.client.Repositories.CreateFile(ctx, gh.owner, gh.repoName, "main.tf", opts)
-	if err != nil {
-		gh.t.Fatal(err.Error())
-	}
-}
-
-func (gh *GitHubClient) DeleteRepository(ctx context.Context) {
-	_, err := gh.client.Repositories.Delete(ctx, gh.owner, *gh.repository.Name)
-	if err != nil {
-		gh.t.Fatal(err.Error())
-	}
-}
-
 func TestIMCloudBuildWorkspaceGitHub(t *testing.T) {
 	ctx := context.Background()
 
 	githubPAT := cftutils.ValFromEnv(t, "IM_GITHUB_PAT")
-	client := NewGitHubClient(t, githubPAT, "im-goose", fmt.Sprintf("im-blueprint-test-%s", utils.GetRandomStringFromSetup(t)))
-
-	repo := client.GetRepository(ctx)
-	if repo == nil {
-		client.CreateRepository(ctx, client.owner, client.repoName)
-		client.AddFileToRepository(ctx, utils.GetFileContents(t, "files/main.tf"))
-	}
+	client := NewGitHubClient(t, githubPAT, githubOwner, githubRepo)
 
 	// Testing the module's feature of appending the ".git" suffix if it's missing
 	repoURL := strings.TrimSuffix(client.repository.GetCloneURL(), ".git")
@@ -164,10 +131,6 @@ func TestIMCloudBuildWorkspaceGitHub(t *testing.T) {
 			pr := client.GetOpenPullRequest(ctx, "preview")
 			if pr != nil {
 				client.ClosePullRequest(ctx, pr)
-			}
-			// Delete the repository if we hit a failed state
-			if t.Failed() {
-				client.DeleteRepository(ctx)
 			}
 		})
 
@@ -260,7 +223,7 @@ func TestIMCloudBuildWorkspaceGitHub(t *testing.T) {
 					return true, nil
 				}
 			}
-			cftutils.Poll(t, pollCloudBuild(buildListCmd), 20, 10*time.Second)
+			cftutils.Poll(t, pollCloudBuild(buildListCmd), 40, 10*time.Second)
 			build := gcloud.Run(t, buildListCmd, gcloud.WithLogger(logger.Discard)).Array()[0]
 
 			switch branch {
@@ -275,7 +238,6 @@ func TestIMCloudBuildWorkspaceGitHub(t *testing.T) {
 	bpt.DefineTeardown(func(assert *assert.Assertions) {
 		// Guarantee clean up even if the normal gcloud/teardown run into errors
 		t.Cleanup(func() {
-			client.DeleteRepository(ctx)
 			bpt.DefaultTeardown(assert)
 		})
 		projectID := bpt.GetStringOutput("project_id")


### PR DESCRIPTION
Switching to a test user with a different PAT (`infra-manager-bootstrap-module`), which also uses a different GitHub app ID for our example. Also cleaned up the test to re-use a single repository for connections and PRs, as it previously wasn't cleaning up repositories consistently.

Removed any code that wasn't being called now, such as creating/deleting repositories. Also bumped up the Cloud Build poll retry count, as I noticed it could creep up close to the 20 retry limit when testing.

Already updated the PAT in the secrets project.