### PR TITLE
fix: bump google provider constraints to v7

### DIFF
--- a/modules/cloudbuild/versions.tf
+++ b/modules/cloudbuild/versions.tf
@@ -21,12 +21,12 @@ terraform {
     google = {
       source = "hashicorp/google"
       # Exclude 4.31.0 for https://github.com/hashicorp/terraform-provider-google/issues/12226
-      version = ">= 3.50, != 4.31.0, <7"
+      version = ">= 3.50, != 4.31.0, <8"
     }
     google-beta = {
       source = "hashicorp/google-beta"
       # Exclude 4.31.0 for https://github.com/hashicorp/terraform-provider-google/issues/12226
-      version = ">= 3.50, != 4.31.0, <7"
+      version = ">= 3.50, != 4.31.0, <8"
     }
     random = {
       source  = "hashicorp/random"

--- a/modules/cloudbuild_repo_connection/versions.tf
+++ b/modules/cloudbuild_repo_connection/versions.tf
@@ -21,7 +21,7 @@ terraform {
     google = {
       source = "hashicorp/google"
       # Exclude 4.31.0 for https://github.com/hashicorp/terraform-provider-google/issues/12226
-      version = ">= 4.17, != 4.31.0, < 7"
+      version = ">= 4.17, != 4.31.0, < 8"
     }
 
     time = {
@@ -37,7 +37,7 @@ terraform {
     google-beta = {
       source = "hashicorp/google-beta"
       # Exclude 4.31.0 for https://github.com/hashicorp/terraform-provider-google/issues/12226
-      version = ">= 4.17, != 4.31.0, < 7"
+      version = ">= 4.17, != 4.31.0, < 8"
     }
   }
 }

--- a/modules/im_cloudbuild_workspace/versions.tf
+++ b/modules/im_cloudbuild_workspace/versions.tf
@@ -21,12 +21,12 @@ terraform {
     google = {
       source = "hashicorp/google"
       # Exclude 4.31.0 for https://github.com/hashicorp/terraform-provider-google/issues/12226
-      version = ">= 4.17, != 4.31.0, < 7"
+      version = ">= 4.17, != 4.31.0, < 8"
     }
     google-beta = {
       source = "hashicorp/google-beta"
       # Exclude 4.31.0 for https://github.com/hashicorp/terraform-provider-google/issues/12226
-      version = ">= 4.17, != 4.31.0, < 7"
+      version = ">= 4.17, != 4.31.0, < 8"
     }
     random = {
       source  = "hashicorp/random"

--- a/modules/tf_cloudbuild_builder/versions.tf
+++ b/modules/tf_cloudbuild_builder/versions.tf
@@ -21,12 +21,12 @@ terraform {
     google = {
       source = "hashicorp/google"
       # Exclude 4.31.0 for https://github.com/hashicorp/terraform-provider-google/issues/12226
-      version = ">= 3.50, != 4.31.0, < 7"
+      version = ">= 3.50, != 4.31.0, < 8"
     }
     google-beta = {
       source = "hashicorp/google-beta"
       # Exclude 4.31.0 for https://github.com/hashicorp/terraform-provider-google/issues/12226
-      version = ">= 3.50, != 4.31.0, < 7"
+      version = ">= 3.50, != 4.31.0, < 8"
     }
   }
 

--- a/modules/tf_cloudbuild_source/versions.tf
+++ b/modules/tf_cloudbuild_source/versions.tf
@@ -21,12 +21,12 @@ terraform {
     google = {
       source = "hashicorp/google"
       # Exclude 4.31.0 for https://github.com/hashicorp/terraform-provider-google/issues/12226
-      version = ">= 3.50, != 4.31.0, < 7"
+      version = ">= 3.50, != 4.31.0, < 8"
     }
     google-beta = {
       source = "hashicorp/google-beta"
       # Exclude 4.31.0 for https://github.com/hashicorp/terraform-provider-google/issues/12226
-      version = ">= 3.50, != 4.31.0, < 7"
+      version = ">= 3.50, != 4.31.0, < 8"
     }
   }
 

--- a/modules/tf_cloudbuild_workspace/versions.tf
+++ b/modules/tf_cloudbuild_workspace/versions.tf
@@ -21,12 +21,12 @@ terraform {
     google = {
       source = "hashicorp/google"
       # Exclude 4.31.0 for https://github.com/hashicorp/terraform-provider-google/issues/12226
-      version = ">= 4.17, != 4.31.0, < 7"
+      version = ">= 4.17, != 4.31.0, < 8"
     }
     google-beta = {
       source = "hashicorp/google-beta"
       # Exclude 4.31.0 for https://github.com/hashicorp/terraform-provider-google/issues/12226
-      version = ">= 4.17, != 4.31.0, < 7"
+      version = ">= 4.17, != 4.31.0, < 8"
     }
   }
 

--- a/test/setup/versions.tf
+++ b/test/setup/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 3.50, < 7"
+      version = ">= 3.50, < 8"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 3.50, < 7"
+      version = ">= 3.50, < 8"
     }
     random = {
       source = "hashicorp/random"

--- a/versions.tf
+++ b/versions.tf
@@ -20,7 +20,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 3.50, < 7"
+      version = ">= 3.50, < 8"
     }
     random = {
       source  = "hashicorp/random"


### PR DESCRIPTION
Similar to https://github.com/terraform-google-modules/terraform-google-lb-http/pull/556, we just bump the version constraints