### PR TITLE
fix: Clean up webhooks after GitLab tests

### DIFF
--- a/examples/im_cloudbuild_workspace_gitlab/README.md
+++ b/examples/im_cloudbuild_workspace_gitlab/README.md
@@ -22,5 +22,6 @@ This example demonstrates the simplest usage of the [im_cloudbuild_workspace](..
 | gitlab\_read\_api\_secret\_id | The secret ID for the secret containing the GitLab read api access token. |
 | infra\_manager\_sa | Service account used by Infrastructure Manager |
 | project\_id | n/a |
+| webhook\_key | The random UUID used as webhook key |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/im_cloudbuild_workspace_gitlab/outputs.tf
+++ b/examples/im_cloudbuild_workspace_gitlab/outputs.tf
@@ -49,3 +49,8 @@ output "gitlab_read_api_secret_id" {
   value       = module.im_workspace.gitlab_read_api_secret_id
   sensitive   = true
 }
+
+output "webhook_key" {
+  description = "The random UUID used as webhook key"
+  value       = module.im_workspace.webhook_key
+}

--- a/modules/im_cloudbuild_workspace/README.md
+++ b/modules/im_cloudbuild_workspace/README.md
@@ -93,6 +93,7 @@ for actuating resources.
 | infra\_manager\_sa | Service account used by Infrastructure Manager |
 | repo\_connection\_id | The Cloud Build repository connection ID |
 | vcs\_connection\_id | The Cloud Build VCS host connection ID |
+| webhook\_key | The random UUID used as webhook key |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 

--- a/modules/im_cloudbuild_workspace/outputs.tf
+++ b/modules/im_cloudbuild_workspace/outputs.tf
@@ -61,3 +61,8 @@ output "gitlab_read_api_secret_id" {
   value       = local.read_api_secret_id
   sensitive   = true
 }
+
+output "webhook_key" {
+  description = "The random UUID used as webhook key"
+  value       = local.is_gl_repo ? random_uuid.random_webhook_secret[0].result : ""
+}

--- a/test/fixtures/cloudbuild_repo_connection_gitlab/outputs.tf
+++ b/test/fixtures/cloudbuild_repo_connection_gitlab/outputs.tf
@@ -23,3 +23,8 @@ output "cloud_build_repositories_2nd_gen_repositories" {
   description = "Created repositories."
   value       = module.example.cloud_build_repositories_2nd_gen_repositories
 }
+
+output "webhook_key" {
+  description = "The random UUID used as webhook key"
+  value       = random_uuid.random_webhook_secret.result
+}

--- a/test/fixtures/tf_cloudbuild_builder_simple_gitlab/outputs.tf
+++ b/test/fixtures/tf_cloudbuild_builder_simple_gitlab/outputs.tf
@@ -48,3 +48,8 @@ output "location" {
   description = "The location in which the resources were provisioned"
   value       = module.example.location
 }
+
+output "webhook_key" {
+  description = "The random UUID used as webhook key"
+  value       = random_uuid.random_webhook_secret.result
+}

--- a/test/fixtures/tf_cloudbuild_workspace_simple_gitlab/outputs.tf
+++ b/test/fixtures/tf_cloudbuild_workspace_simple_gitlab/outputs.tf
@@ -53,3 +53,8 @@ output "location" {
   description = "The location in which the resources were provisioned"
   value       = module.example.location
 }
+
+output "webhook_key" {
+  description = "The random UUID used as webhook key"
+  value       = random_uuid.random_webhook_secret.result
+}

--- a/test/integration/cloudbuild_repo_connection_gitlab/cloudbuild_repo_connection_gitlab_test.go
+++ b/test/integration/cloudbuild_repo_connection_gitlab/cloudbuild_repo_connection_gitlab_test.go
@@ -76,6 +76,10 @@ func TestCloudBuildRepoConnectionGitLab(t *testing.T) {
 		t.Cleanup(func() {
 			bpt.DefaultTeardown(assert)
 		})
+		webhookKey := bpt.GetStringOutput("webhook_key")
+		t.Cleanup(func() {
+			client.DeleteWebhookByKey(webhookKey)
+		})
 	})
 
 	bpt.Test()

--- a/test/integration/im_cloudbuild_workspace_gitlab/im_cloudbuild_workspace_gitlab_test.go
+++ b/test/integration/im_cloudbuild_workspace_gitlab/im_cloudbuild_workspace_gitlab_test.go
@@ -168,6 +168,10 @@ func TestIMCloudBuildWorkspaceGitLab(t *testing.T) {
 		t.Cleanup(func() {
 			bpt.DefaultTeardown(assert)
 		})
+		webhookKey := bpt.GetStringOutput("webhook_key")
+		t.Cleanup(func() {
+			client.DeleteWebhookByKey(webhookKey)
+		})
 		projectID := bpt.GetStringOutput("project_id")
 		gcloud.Runf(t, "infra-manager deployments delete projects/%s/locations/us-central1/deployments/im-example-gitlab-deployment --project %s --quiet", projectID, projectID)
 	})

--- a/test/integration/tf_cloudbuild_builder_simple_gitlab/tf_cloudbuild_builder_simple_gitlab_test.go
+++ b/test/integration/tf_cloudbuild_builder_simple_gitlab/tf_cloudbuild_builder_simple_gitlab_test.go
@@ -150,6 +150,10 @@ func TestTFCloudBuildBuilderGitLab(t *testing.T) {
 		t.Cleanup(func() {
 			bpt.DefaultTeardown(assert)
 		})
+		webhookKey := bpt.GetStringOutput("webhook_key")
+		t.Cleanup(func() {
+			client.DeleteWebhookByKey(webhookKey)
+		})
 	})
 
 	bpt.Test()

--- a/test/integration/tf_cloudbuild_workspace_simple_gitlab/tf_cloudbuild_workspace_simple_gitlab_test.go
+++ b/test/integration/tf_cloudbuild_workspace_simple_gitlab/tf_cloudbuild_workspace_simple_gitlab_test.go
@@ -149,6 +149,10 @@ func TestCloudBuildWorkspaceSimpleGitLab(t *testing.T) {
 		t.Cleanup(func() {
 			bpt.DefaultTeardown(assert)
 		})
+		webhookKey := bpt.GetStringOutput("webhook_key")
+		t.Cleanup(func() {
+			client.DeleteWebhookByKey(webhookKey)
+		})
 	})
 
 	bpt.Test()

--- a/test/integration/utils/gitlab_client.go
+++ b/test/integration/utils/gitlab_client.go
@@ -16,6 +16,7 @@ package utils
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/xanzy/go-gitlab"
@@ -111,4 +112,39 @@ func (gl *GitLabClient) AcceptMergeRequest(mr *gitlab.MergeRequest, commitMessag
 		gl.t.Fatalf("failed to accept merge request %v", resp)
 	}
 	return merged
+}
+
+// DeleteWebhookByKey deletes webhooks for the project that contain the given key in their URL.
+func (gl *GitLabClient) DeleteWebhookByKey(webhookKey string) {
+	if webhookKey == "" {
+		gl.t.Log("Webhook key is empty, skipping deletion.")
+		return
+	}
+
+	opts := &gitlab.ListProjectHooksOptions{
+		PerPage: 100,
+		Page:    1,
+	}
+
+	for {
+		hooks, resp, err := gl.client.Projects.ListProjectHooks(gl.ProjectName(), opts)
+		if err != nil {
+			gl.t.Fatal(err.Error())
+		}
+
+		for _, hook := range hooks {
+			if strings.Contains(hook.URL, webhookKey) {
+				_, err := gl.client.Projects.DeleteProjectHook(gl.ProjectName(), hook.ID)
+				if err != nil {
+					gl.t.Fatal(err.Error())
+				}
+				gl.t.Logf("Deleted GitLab webhook with ID %d and URL %s", hook.ID, hook.URL)
+			}
+		}
+
+		if resp.NextPage == 0 {
+			break
+		}
+		opts.Page = resp.NextPage
+	}
 }


### PR DESCRIPTION
When setting up a Cloud Build GitLab connection, a webhook is created for that project on GitLab. When tearing down the test, the Cloud Build connection is cleaned up, but the GitLab project webhook remains.

The webhook gets an identifier based off of the Cloud Build connection and can be used to query for webhooks in that project and then cleaned up.

Tested locally and verified the webhook was cleaned up.