### PR TITLE
feat: add support for Google Universes for the main module

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,14 +54,14 @@ For the cloudbuild submodule, see the README [cloudbuild](./modules/cloudbuild).
 | folder\_id | The ID of a folder to host this project | `string` | `""` | no |
 | force\_destroy | If supplied, the state bucket will be deleted even while containing objects. | `bool` | `false` | no |
 | grant\_billing\_user | Grant roles/billing.user role to CFT service account | `bool` | `true` | no |
-| group\_billing\_admins | Google Group for GCP Billing Administrators | `string` | n/a | yes |
-| group\_org\_admins | Google Group for GCP Organization Administrators | `string` | n/a | yes |
+| group\_billing\_admins | Google Group or principalSet URI (e.g., 'principalSet://...') for GCP Billing Administrators | `string` | n/a | yes |
+| group\_org\_admins | Google Group or principalSet URI (e.g., 'principalSet://...') for GCP Organization Administrators | `string` | n/a | yes |
 | key\_protection\_level | The protection level to use when creating a version based on this template. Default value: "SOFTWARE" Possible values: ["SOFTWARE", "HSM"] | `string` | `"SOFTWARE"` | no |
 | key\_rotation\_period | The rotation period of the key. | `string` | `null` | no |
 | kms\_prevent\_destroy | Set the prevent\_destroy lifecycle attribute on keys. | `bool` | `true` | no |
 | org\_admins\_org\_iam\_permissions | List of permissions granted to the group supplied in group\_org\_admins variable across the GCP organization. | `list(string)` | <pre>[<br>  "roles/billing.user",<br>  "roles/resourcemanager.organizationAdmin"<br>]</pre> | no |
 | org\_id | GCP Organization ID | `string` | n/a | yes |
-| org\_project\_creators | Additional list of members to have project creator role accross the organization. Prefix of group: user: or serviceAccount: is required. | `list(string)` | `[]` | no |
+| org\_project\_creators | Additional list of members to have project creator role across the organization. Prefix of group: user: serviceAccount: or principalSet:// is required. | `list(string)` | `[]` | no |
 | parent\_folder | GCP parent folder ID in the form folders/{id} | `string` | `""` | no |
 | project\_auto\_create\_network | Create the default network for the project created. | `bool` | `false` | no |
 | project\_deletion\_policy | The deletion policy for the project created. | `string` | `"PREVENT"` | no |
@@ -75,6 +75,7 @@ For the cloudbuild submodule, see the README [cloudbuild](./modules/cloudbuild).
 | storage\_bucket\_labels | Labels to apply to the storage bucket. | `map(string)` | `{}` | no |
 | tf\_service\_account\_id | ID of service account for terraform in seed project | `string` | `"org-terraform"` | no |
 | tf\_service\_account\_name | Display name of service account for terraform in seed project | `string` | `"CFT Organization Terraform Account"` | no |
+| universe\_prefix | The universe short name prefix to prepend to the project ID (e.g., 'eu0'). A colon (:) is automatically appended to the project ID. | `string` | `""` | no |
 
 ## Outputs
 

--- a/examples/cloudbuild_enabled/main.tf
+++ b/examples/cloudbuild_enabled/main.tf
@@ -20,7 +20,7 @@
 
 module "seed_bootstrap" {
   source  = "terraform-google-modules/bootstrap/google"
-  version = "~> 11.0"
+  version = "~> 12.0"
 
   org_id                  = var.org_id
   billing_account         = var.billing_account
@@ -36,7 +36,7 @@ module "seed_bootstrap" {
 
 module "cloudbuild_bootstrap" {
   source  = "terraform-google-modules/bootstrap/google//modules/cloudbuild"
-  version = "~> 11.0"
+  version = "~> 12.0"
 
   org_id                  = var.org_id
   billing_account         = var.billing_account

--- a/examples/cloudbuild_repo_connection_github/main.tf
+++ b/examples/cloudbuild_repo_connection_github/main.tf
@@ -16,7 +16,7 @@
 
 module "git_repo_connection" {
   source  = "terraform-google-modules/bootstrap/google//modules/cloudbuild_repo_connection"
-  version = "~> 11.0"
+  version = "~> 12.0"
 
   project_id = var.project_id
   connection_config = {

--- a/examples/cloudbuild_repo_connection_gitlab/main.tf
+++ b/examples/cloudbuild_repo_connection_gitlab/main.tf
@@ -16,7 +16,7 @@
 
 module "git_repo_connection" {
   source  = "terraform-google-modules/bootstrap/google//modules/cloudbuild_repo_connection"
-  version = "~> 11.0"
+  version = "~> 12.0"
 
   project_id = var.project_id
   connection_config = {

--- a/examples/im_cloudbuild_workspace_github/main.tf
+++ b/examples/im_cloudbuild_workspace_github/main.tf
@@ -16,7 +16,7 @@
 
 module "im_workspace" {
   source  = "terraform-google-modules/bootstrap/google//modules/im_cloudbuild_workspace"
-  version = "~> 11.0"
+  version = "~> 12.0"
 
   project_id    = var.project_id
   deployment_id = "im-example-github-deployment"

--- a/examples/im_cloudbuild_workspace_gitlab/main.tf
+++ b/examples/im_cloudbuild_workspace_gitlab/main.tf
@@ -16,7 +16,7 @@
 
 module "im_workspace" {
   source  = "terraform-google-modules/bootstrap/google//modules/im_cloudbuild_workspace"
-  version = "~> 11.0"
+  version = "~> 12.0"
 
   project_id    = var.project_id
   deployment_id = "im-example-gitlab-deployment"

--- a/examples/simple-folder/main.tf
+++ b/examples/simple-folder/main.tf
@@ -20,7 +20,7 @@
 
 module "seed_bootstrap" {
   source  = "terraform-google-modules/bootstrap/google"
-  version = "~> 11.0"
+  version = "~> 12.0"
 
   org_id                  = var.org_id
   parent_folder           = var.parent

--- a/examples/simple/main.tf
+++ b/examples/simple/main.tf
@@ -20,7 +20,7 @@
 
 module "seed_bootstrap" {
   source  = "terraform-google-modules/bootstrap/google"
-  version = "~> 11.0"
+  version = "~> 12.0"
 
   org_id                  = var.org_id
   billing_account         = var.billing_account

--- a/examples/tf_cloudbuild_builder_simple/main.tf
+++ b/examples/tf_cloudbuild_builder_simple/main.tf
@@ -16,7 +16,7 @@
 
 module "cloudbuilder" {
   source  = "terraform-google-modules/bootstrap/google//modules/tf_cloudbuild_builder"
-  version = "~> 11.0"
+  version = "~> 12.0"
 
   project_id          = module.enabled_google_apis.project_id
   dockerfile_repo_uri = google_sourcerepo_repository.builder_dockerfile_repo.url

--- a/examples/tf_cloudbuild_builder_simple_github/main.tf
+++ b/examples/tf_cloudbuild_builder_simple_github/main.tf
@@ -26,7 +26,7 @@ locals {
 
 module "cloudbuilder" {
   source  = "terraform-google-modules/bootstrap/google//modules/tf_cloudbuild_builder"
-  version = "~> 11.0"
+  version = "~> 12.0"
 
   project_id                  = module.enabled_google_apis.project_id
   dockerfile_repo_uri         = module.git_repo_connection.cloud_build_repositories_2nd_gen_repositories["test_repo"].id
@@ -56,7 +56,7 @@ resource "time_sleep" "propagation" {
 
 module "git_repo_connection" {
   source  = "terraform-google-modules/bootstrap/google//modules/cloudbuild_repo_connection"
-  version = "~> 11.0"
+  version = "~> 12.0"
 
   project_id = var.project_id
   connection_config = {

--- a/examples/tf_cloudbuild_builder_simple_gitlab/main.tf
+++ b/examples/tf_cloudbuild_builder_simple_gitlab/main.tf
@@ -26,7 +26,7 @@ locals {
 
 module "cloudbuilder" {
   source  = "terraform-google-modules/bootstrap/google//modules/tf_cloudbuild_builder"
-  version = "~> 11.0"
+  version = "~> 12.0"
 
   project_id                  = module.enabled_google_apis.project_id
   dockerfile_repo_uri         = module.git_repo_connection.cloud_build_repositories_2nd_gen_repositories["test_repo"].id
@@ -59,7 +59,7 @@ resource "time_sleep" "propagation" {
 
 module "git_repo_connection" {
   source  = "terraform-google-modules/bootstrap/google//modules/cloudbuild_repo_connection"
-  version = "~> 11.0"
+  version = "~> 12.0"
 
   project_id = var.project_id
   connection_config = {

--- a/examples/tf_cloudbuild_source_simple/main.tf
+++ b/examples/tf_cloudbuild_source_simple/main.tf
@@ -16,7 +16,7 @@
 
 module "tf_source" {
   source  = "terraform-google-modules/bootstrap/google//modules/tf_cloudbuild_source"
-  version = "~> 11.0"
+  version = "~> 12.0"
 
   org_id                  = var.org_id
   folder_id               = var.parent_folder

--- a/examples/tf_cloudbuild_workspace_simple/main.tf
+++ b/examples/tf_cloudbuild_workspace_simple/main.tf
@@ -16,7 +16,7 @@
 
 module "tf_workspace" {
   source  = "terraform-google-modules/bootstrap/google//modules/tf_cloudbuild_workspace"
-  version = "~> 11.0"
+  version = "~> 12.0"
 
   project_id       = module.enabled_google_apis.project_id
   tf_repo_uri      = google_sourcerepo_repository.tf_config_repo.url

--- a/examples/tf_cloudbuild_workspace_simple_github/main.tf
+++ b/examples/tf_cloudbuild_workspace_simple_github/main.tf
@@ -26,7 +26,7 @@ locals {
 
 module "tf_workspace" {
   source  = "terraform-google-modules/bootstrap/google//modules/tf_cloudbuild_workspace"
-  version = "~> 11.0"
+  version = "~> 12.0"
 
   project_id                = module.enabled_google_apis.project_id
   tf_repo_type              = "CLOUDBUILD_V2_REPOSITORY"
@@ -61,7 +61,7 @@ resource "time_sleep" "propagation" {
 
 module "git_repo_connection" {
   source  = "terraform-google-modules/bootstrap/google//modules/cloudbuild_repo_connection"
-  version = "~> 11.0"
+  version = "~> 12.0"
 
   project_id = var.project_id
   connection_config = {

--- a/examples/tf_cloudbuild_workspace_simple_gitlab/main.tf
+++ b/examples/tf_cloudbuild_workspace_simple_gitlab/main.tf
@@ -26,7 +26,7 @@ locals {
 
 module "tf_workspace" {
   source  = "terraform-google-modules/bootstrap/google//modules/tf_cloudbuild_workspace"
-  version = "~> 11.0"
+  version = "~> 12.0"
 
   project_id               = module.enabled_google_apis.project_id
   tf_repo_type             = "CLOUDBUILD_V2_REPOSITORY"
@@ -60,7 +60,7 @@ resource "time_sleep" "propagation" {
 
 module "git_repo_connection" {
   source  = "terraform-google-modules/bootstrap/google//modules/cloudbuild_repo_connection"
-  version = "~> 11.0"
+  version = "~> 12.0"
 
   project_id = var.project_id
   connection_config = {

--- a/main.tf
+++ b/main.tf
@@ -23,10 +23,18 @@ locals {
   impersonation_apis         = distinct(concat(local.base_apis, ["serviceusage.googleapis.com", "iamcredentials.googleapis.com"]))
   activate_apis              = var.sa_enable_impersonation == true ? local.impersonation_apis : local.base_apis
   org_project_creators_tf_sa = var.create_terraform_sa ? ["serviceAccount:${google_service_account.org_terraform[0].email}"] : []
-  org_project_creators       = distinct(concat(var.org_project_creators, local.org_project_creators_tf_sa, ["group:${var.group_org_admins}"]))
+  org_project_creators       = distinct(concat(var.org_project_creators, local.org_project_creators_tf_sa, [local.group_org_admins_id]))
   is_organization            = var.parent_folder == "" ? true : false
   parent_id                  = var.parent_folder == "" ? var.org_id : split("/", var.parent_folder)[1]
   seed_org_depends_on        = try(google_folder_iam_member.tmp_project_creator[0].etag, "") != "" ? var.org_id : google_organization_iam_member.tmp_project_creator[0].org_id
+
+  group_billing_admins_id = var.group_billing_admins != "" ? (
+    startswith(var.group_billing_admins, "principalSet://") || startswith(var.group_billing_admins, "group:") ? var.group_billing_admins : "group:${var.group_billing_admins}"
+  ) : ""
+
+  group_org_admins_id = var.group_org_admins != "" ? (
+    startswith(var.group_org_admins, "principalSet://") || startswith(var.group_org_admins, "group:") ? var.group_org_admins : "group:${var.group_org_admins}"
+  ) : ""
 }
 
 resource "random_id" "suffix" {
@@ -42,7 +50,7 @@ resource "google_organization_iam_member" "tmp_project_creator" {
 
   org_id = local.parent_id
   role   = "roles/resourcemanager.projectCreator"
-  member = "group:${var.group_org_admins}"
+  member = local.group_org_admins_id
 }
 
 resource "google_folder_iam_member" "tmp_project_creator" {
@@ -50,7 +58,7 @@ resource "google_folder_iam_member" "tmp_project_creator" {
 
   folder = local.parent_id
   role   = "roles/resourcemanager.projectCreator"
-  member = "group:${var.group_org_admins}"
+  member = local.group_org_admins_id
 }
 
 /******************************************
@@ -58,10 +66,12 @@ resource "google_folder_iam_member" "tmp_project_creator" {
 *******************************************/
 
 module "seed_project" {
-  source                      = "terraform-google-modules/project-factory/google"
-  version                     = "~> 18.0"
+  source  = "terraform-google-modules/project-factory/google"
+  version = "~> 18.0"
+
   name                        = local.seed_project_id
   random_project_id           = var.random_suffix
+  universe_prefix             = var.universe_prefix
   disable_services_on_destroy = false
   folder_id                   = var.folder_id
   org_id                      = local.seed_org_depends_on
@@ -130,6 +140,7 @@ module "kms" {
     "serviceAccount:${data.google_storage_project_service_account.gcs_account.email_address}",
   ]
   prevent_destroy = var.kms_prevent_destroy
+
 }
 
 resource "google_storage_bucket" "org_terraform_state" {
@@ -161,7 +172,7 @@ resource "google_organization_iam_binding" "billing_creator" {
   org_id = var.org_id
   role   = "roles/billing.creator"
   members = [
-    "group:${var.group_billing_admins}",
+    local.group_billing_admins_id,
   ]
 }
 
@@ -190,7 +201,7 @@ resource "google_organization_iam_member" "org_admins_group" {
 
   org_id = var.org_id
   role   = each.value
-  member = "group:${var.group_org_admins}"
+  member = local.group_org_admins_id
 }
 
 /***********************************************
@@ -200,7 +211,7 @@ resource "google_organization_iam_member" "org_admins_group" {
 resource "google_organization_iam_member" "org_billing_admin" {
   org_id = var.org_id
   role   = "roles/billing.admin"
-  member = "group:${var.group_billing_admins}"
+  member = local.group_billing_admins_id
 }
 
 /***********************************************
@@ -241,7 +252,7 @@ resource "google_service_account_iam_member" "org_admin_sa_user" {
 
   service_account_id = google_service_account.org_terraform[0].name
   role               = "roles/iam.serviceAccountUser"
-  member             = "group:${var.group_org_admins}"
+  member             = local.group_org_admins_id
 }
 
 resource "google_service_account_iam_member" "org_admin_sa_impersonate_permissions" {
@@ -249,7 +260,7 @@ resource "google_service_account_iam_member" "org_admin_sa_impersonate_permissio
 
   service_account_id = google_service_account.org_terraform[0].name
   role               = "roles/iam.serviceAccountTokenCreator"
-  member             = "group:${var.group_org_admins}"
+  member             = local.group_org_admins_id
 }
 
 resource "google_organization_iam_member" "org_admin_serviceusage_consumer" {
@@ -257,7 +268,7 @@ resource "google_organization_iam_member" "org_admin_serviceusage_consumer" {
 
   org_id = local.parent_id
   role   = "roles/serviceusage.serviceUsageConsumer"
-  member = "group:${var.group_org_admins}"
+  member = local.group_org_admins_id
 }
 
 resource "google_folder_iam_member" "org_admin_service_account_user" {
@@ -265,7 +276,7 @@ resource "google_folder_iam_member" "org_admin_service_account_user" {
 
   folder = local.parent_id
   role   = "roles/iam.serviceAccountUser"
-  member = "group:${var.group_org_admins}"
+  member = local.group_org_admins_id
 }
 
 resource "google_folder_iam_member" "org_admin_serviceusage_consumer" {
@@ -273,7 +284,7 @@ resource "google_folder_iam_member" "org_admin_serviceusage_consumer" {
 
   folder = local.parent_id
   role   = "roles/serviceusage.serviceUsageConsumer"
-  member = "group:${var.group_org_admins}"
+  member = local.group_org_admins_id
 }
 
 resource "google_storage_bucket_iam_member" "orgadmins_state_iam" {
@@ -281,5 +292,5 @@ resource "google_storage_bucket_iam_member" "orgadmins_state_iam" {
 
   bucket = google_storage_bucket.org_terraform_state.name
   role   = "roles/storage.admin"
-  member = "group:${var.group_org_admins}"
+  member = local.group_org_admins_id
 }

--- a/main.tf
+++ b/main.tf
@@ -27,14 +27,8 @@ locals {
   is_organization            = var.parent_folder == "" ? true : false
   parent_id                  = var.parent_folder == "" ? var.org_id : split("/", var.parent_folder)[1]
   seed_org_depends_on        = try(google_folder_iam_member.tmp_project_creator[0].etag, "") != "" ? var.org_id : google_organization_iam_member.tmp_project_creator[0].org_id
-
-  group_billing_admins_id = var.group_billing_admins != "" ? (
-    startswith(var.group_billing_admins, "principalSet://") || startswith(var.group_billing_admins, "group:") ? var.group_billing_admins : "group:${var.group_billing_admins}"
-  ) : ""
-
-  group_org_admins_id = var.group_org_admins != "" ? (
-    startswith(var.group_org_admins, "principalSet://") || startswith(var.group_org_admins, "group:") ? var.group_org_admins : "group:${var.group_org_admins}"
-  ) : ""
+  group_billing_admins_id    = startswith(var.group_billing_admins, "principalSet://") || startswith(var.group_billing_admins, "group:") ? var.group_billing_admins : "group:${var.group_billing_admins}"
+  group_org_admins_id        = startswith(var.group_org_admins, "principalSet://") || startswith(var.group_org_admins, "group:") ? var.group_org_admins : "group:${var.group_org_admins}"
 }
 
 resource "random_id" "suffix" {
@@ -67,7 +61,7 @@ resource "google_folder_iam_member" "tmp_project_creator" {
 
 module "seed_project" {
   source  = "terraform-google-modules/project-factory/google"
-  version = "~> 18.0"
+  version = "~> 18.3"
 
   name                        = local.seed_project_id
   random_project_id           = var.random_suffix

--- a/variables.tf
+++ b/variables.tf
@@ -35,12 +35,12 @@ variable "billing_account" {
 }
 
 variable "group_org_admins" {
-  description = "Google Group for GCP Organization Administrators"
+  description = "Google Group or principalSet URI (e.g., 'principalSet://...') for GCP Organization Administrators"
   type        = string
 }
 
 variable "group_billing_admins" {
-  description = "Google Group for GCP Billing Administrators"
+  description = "Google Group or principalSet URI (e.g., 'principalSet://...') for GCP Billing Administrators"
   type        = string
 }
 
@@ -70,6 +70,17 @@ variable "project_id" {
   description = "Custom project ID to use for project created. If not supplied, the default id is {project_prefix}-seed-{random suffix}."
   default     = ""
   type        = string
+}
+
+variable "universe_prefix" {
+  description = "The universe short name prefix to prepend to the project ID (e.g., 'eu0'). A colon (:) is automatically appended to the project ID."
+  type        = string
+  default     = ""
+
+  validation {
+    condition     = var.universe_prefix == "" || can(regex("^[a-z0-9]+$", var.universe_prefix))
+    error_message = "The universe_prefix variable must be empty or contain only lowercase alphanumeric characters."
+  }
 }
 
 variable "project_deletion_policy" {
@@ -172,7 +183,7 @@ variable "folder_id" {
 }
 
 variable "org_project_creators" {
-  description = "Additional list of members to have project creator role accross the organization. Prefix of group: user: or serviceAccount: is required."
+  description = "Additional list of members to have project creator role across the organization. Prefix of group: user: serviceAccount: or principalSet:// is required."
   type        = list(string)
   default     = []
 }

--- a/variables.tf
+++ b/variables.tf
@@ -76,11 +76,6 @@ variable "universe_prefix" {
   description = "The universe short name prefix to prepend to the project ID (e.g., 'eu0'). A colon (:) is automatically appended to the project ID."
   type        = string
   default     = ""
-
-  validation {
-    condition     = var.universe_prefix == "" || can(regex("^[a-z0-9]+$", var.universe_prefix))
-    error_message = "The universe_prefix variable must be empty or contain only lowercase alphanumeric characters."
-  }
 }
 
 variable "project_deletion_policy" {


### PR DESCRIPTION
This PR adds support for Google universes in the main module.
This change includes:

- Add `universe_prefix` variable for the prefix used in the creation of the `seed` project 
- Add support for `principalSet` in the variables that require groups.

This PR does not address support for Google universes in the Cloud Build Workspace projects since Cloud Build API is not supported yet.