### PR TITLE
chore: Update state bucket settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,9 @@ For the cloudbuild submodule, see the README [cloudbuild](./modules/cloudbuild).
 | random\_suffix | Appends a 4 character random suffix to project ID and GCS bucket name. | `bool` | `true` | no |
 | sa\_enable\_impersonation | Allow org\_admins group to impersonate service account & enable APIs required. | `bool` | `false` | no |
 | sa\_org\_iam\_permissions | List of permissions granted to Terraform service account across the GCP organization. | `list(string)` | <pre>[<br>  "roles/billing.user",<br>  "roles/compute.networkAdmin",<br>  "roles/compute.xpnAdmin",<br>  "roles/iam.securityAdmin",<br>  "roles/iam.serviceAccountAdmin",<br>  "roles/logging.configWriter",<br>  "roles/orgpolicy.policyAdmin",<br>  "roles/resourcemanager.folderAdmin",<br>  "roles/resourcemanager.organizationViewer"<br>]</pre> | no |
+| state\_bucket\_lifecycle\_rules | List of optional lifecycle rules for the state bucket. | <pre>list(object({<br>    action    = any<br>    condition = any<br>  }))</pre> | `[]` | no |
 | state\_bucket\_name | Custom state bucket name. If not supplied, the default name is {project\_prefix}-tfstate-{random suffix}. | `string` | `""` | no |
+| state\_bucket\_versioning\_enabled | Boolean to indicate if the object versioning should be enabled for the state bucket. | `bool` | `true` | no |
 | storage\_bucket\_labels | Labels to apply to the storage bucket. | `map(string)` | `{}` | no |
 | tf\_service\_account\_id | ID of service account for terraform in seed project | `string` | `"org-terraform"` | no |
 | tf\_service\_account\_name | Display name of service account for terraform in seed project | `string` | `"CFT Organization Terraform Account"` | no |

--- a/main.tf
+++ b/main.tf
@@ -139,8 +139,26 @@ resource "google_storage_bucket" "org_terraform_state" {
   labels                      = var.storage_bucket_labels
   force_destroy               = var.force_destroy
   uniform_bucket_level_access = true
+
   versioning {
-    enabled = true
+    enabled = var.state_bucket_versioning_enabled
+  }
+
+  dynamic "lifecycle_rule" {
+    for_each = var.state_bucket_lifecycle_rules
+    content {
+      action {
+        type          = lifecycle_rule.value.action.type
+        storage_class = try(lifecycle_rule.value.action.storage_class, null)
+      }
+      condition {
+        age                   = try(lifecycle_rule.value.condition.age, null)
+        created_before        = try(lifecycle_rule.value.condition.created_before, null)
+        with_state            = try(lifecycle_rule.value.condition.with_state, null)
+        matches_storage_class = try(lifecycle_rule.value.condition.matches_storage_class, null)
+        num_newer_versions    = try(lifecycle_rule.value.condition.num_newer_versions, null)
+      }
+    }
   }
 
   dynamic "encryption" {

--- a/test/integration/simple/controls/gcp.rb
+++ b/test/integration/simple/controls/gcp.rb
@@ -35,6 +35,7 @@ control "bootstrap" do
 
   describe google_storage_bucket(name: attribute("gcs_bucket_tfstate")) do
     it { should exist }
+    its('versioning') { should exist }
   end
 
   describe google_storage_bucket_iam_binding(bucket: attribute("gcs_bucket_tfstate"),  role: 'roles/storage.admin') do

--- a/variables.tf
+++ b/variables.tf
@@ -132,10 +132,25 @@ variable "create_terraform_sa" {
   default     = true
 }
 
+variable "state_bucket_lifecycle_rules" {
+  description = "List of optional lifecycle rules for the state bucket."
+  default     = []
+  type = list(object({
+    action    = any
+    condition = any
+  }))
+}
+
 variable "state_bucket_name" {
   description = "Custom state bucket name. If not supplied, the default name is {project_prefix}-tfstate-{random suffix}."
   default     = ""
   type        = string
+}
+
+variable "state_bucket_versioning_enabled" {
+  description = "Boolean to indicate if the object versioning should be enabled for the state bucket."
+  default     = true
+  type        = bool
 }
 
 variable "grant_billing_user" {


### PR DESCRIPTION
Made state bucket `versioning` optional.
Added support for state bucket `lifecycle_rules`.