### PR TITLE
fix: resolve CI test collisions, IAM dependencies, and preview retry logic

### DIFF
--- a/build/int.cloudbuild.yaml
+++ b/build/int.cloudbuild.yaml
@@ -143,22 +143,16 @@ steps:
 - id: teardown-tfbuilder
   waitFor:
       - verify-tfbuilder
-      - verify-tfbuilder-github
-      - verify-tfbuilder-gitlab
   name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
   args: ['/bin/bash', '-c', 'cft test run TestTFCloudBuildBuilder --stage teardown --verbose']
 - id: teardown-tfbuilder-github
   waitFor:
-      - verify-tfbuilder
       - verify-tfbuilder-github
-      - verify-tfbuilder-gitlab
   name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
   args: ['/bin/bash', '-c', 'cft test run TestTFCloudBuildBuilderGitHub --stage teardown --verbose']
   secretEnv: ['IM_GITHUB_PAT']
 - id: teardown-tfbuilder-gitlab
   waitFor:
-      - verify-tfbuilder
-      - verify-tfbuilder-github
       - verify-tfbuilder-gitlab
   name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
   args: ['/bin/bash', '-c', 'cft test run TestTFCloudBuildBuilderGitLab --stage teardown --verbose']

--- a/examples/tf_cloudbuild_builder_simple_github/main.tf
+++ b/examples/tf_cloudbuild_builder_simple_github/main.tf
@@ -38,7 +38,9 @@ module "cloudbuilder" {
   bucket_name                 = "tf-cloudbuilder-build-logs-${var.project_id}-gh"
   gar_repo_name               = "tf-runners-gh"
   workflow_name               = "terraform-runner-workflow-gh"
+  workflow_sa_name            = "tf-workflow-sa-gh"
   trigger_name                = "tf-cloud-builder-build-gh"
+  cloudbuild_sa_name          = "tf-cb-builder-sa-gh"
 
   # allow logs bucket to be destroyed
   cb_logs_bucket_force_destroy = true

--- a/examples/tf_cloudbuild_builder_simple_gitlab/main.tf
+++ b/examples/tf_cloudbuild_builder_simple_gitlab/main.tf
@@ -38,7 +38,9 @@ module "cloudbuilder" {
   bucket_name                 = "tf-cloudbuilder-build-logs-${var.project_id}-gl"
   gar_repo_name               = "tf-runners-gl"
   workflow_name               = "terraform-runner-workflow-gl"
+  workflow_sa_name            = "tf-workflow-sa-gl"
   trigger_name                = "tf-cloud-builder-build-gl"
+  cloudbuild_sa_name          = "tf-cb-builder-sa-gl"
 
   # allow logs bucket to be destroyed
   cb_logs_bucket_force_destroy = true

--- a/modules/cloudbuild_repo_connection/README.md
+++ b/modules/cloudbuild_repo_connection/README.md
@@ -25,3 +25,13 @@ Users will provide the required secrets through the `connection_config` variable
 | cloud\_build\_repositories\_2nd\_gen\_repositories | A map of created repositories associated with the Cloud Build connection.<br>Each entry contains the repository's unique identifier and its remote URL.<br>Example format:<br>"key\_name" = {<br>  "id" =  "projects/{{project}}/locations/{{location}}/connections/{{parent\_connection}}/repositories/{{name}}",<br>  "url" = "https://github.com/{{account/org}}/{{repository_name}}.git"<br>} |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+
+## Troubleshooting
+
+### GitLab Webhook Registration Errors (HTTP 422)
+When creating a `google_cloudbuildv2_repository` resource connected to GitLab, Cloud Build automatically registers a webhook on the target GitLab repository (format: `https://cloudbuild.googleapis.com/v2/.../connections:processWebhook?webhook_key=...`).
+
+If repository creation fails with `generic::failed_precondition: 422: {"error":"Invalid url given"}` or hook limit errors:
+1. **Outbound Request Filtering (SSRF)**: Ensure outbound webhook requests to Google Cloud APIs are permitted under GitLab's **Settings > Network > Outbound requests**.
+2. **DNS & Network Reachability**: Verify that the GitLab server can resolve and contact `cloudbuild.googleapis.com`.
+3. **Hook Limits**: GitLab projects have a limit of 100 webhooks. Stale or orphaned webhooks should be cleaned up under **Project > Settings > Webhooks**.

--- a/modules/im_cloudbuild_workspace/cb.tf
+++ b/modules/im_cloudbuild_workspace/cb.tf
@@ -123,5 +123,14 @@ resource "google_cloudbuild_trigger" "triggers" {
   included_files  = var.cloudbuild_included_files
   ignored_files   = var.cloudbuild_ignored_files
 
-  depends_on = [google_project_iam_member.im_sa_roles]
+  depends_on = [
+    google_project_iam_member.cb_config_admin_role,
+    google_project_iam_member.cb_config_agent_role,
+    google_project_iam_member.cb_logWriter_role,
+    google_project_iam_member.cb_serviceAccountUser_role,
+    google_project_iam_member.cb_storage_objects_viewer,
+    google_project_iam_member.im_config_agent_role,
+    google_project_iam_member.im_sa_logging,
+    google_project_iam_member.im_sa_roles,
+  ]
 }

--- a/modules/im_cloudbuild_workspace/repo.tf
+++ b/modules/im_cloudbuild_workspace/repo.tf
@@ -65,6 +65,11 @@ resource "google_cloudbuildv2_connection" "vcs_connection" {
       webhook_secret_secret_version = google_secret_manager_secret_version.gitlab_webhook_secret_version[0].name
     }
   }
+
+  depends_on = [
+    google_secret_manager_secret_iam_member.github_token_iam_member,
+    google_secret_manager_secret_iam_member.gitlab_secret_members,
+  ]
 }
 
 // Create the repository connection.

--- a/modules/im_cloudbuild_workspace/templates/create-preview.sh.tftpl
+++ b/modules/im_cloudbuild_workspace/templates/create-preview.sh.tftpl
@@ -16,9 +16,6 @@
 echo "Checking if deployment ${deployment_id} already exists"
 DEPLOYMENT_EXISTS=$(gcloud infra-manager deployments list --location ${location} --filter ${deployment_id} | tail -n +2 | wc -l)
 
-echo "Deleting previous preview if it already exists"
-gcloud infra-manager previews delete projects/${project_id}/locations/${location}/previews/preview-$SHORT_SHA --quiet
-
 CREATE_PREVIEW_CMD="gcloud infra-manager previews create projects/${project_id}/locations/${location}/previews/preview-$SHORT_SHA \
   --service-account=${service_account} \
   --git-source-repo=${source_repo} \
@@ -36,11 +33,11 @@ if [[ $DEPLOYMENT_EXISTS -eq 1 ]]; then
   CREATE_PREVIEW_CMD+=" --deployment projects/${project_id}/locations/${location}/deployments/${deployment_id}"
 fi
 
-$CREATE_PREVIEW_CMD
+for i in {1..12}; do
+  gcloud infra-manager previews delete projects/${project_id}/locations/${location}/previews/preview-$SHORT_SHA --quiet || true
+  $CREATE_PREVIEW_CMD && exit 0
+  sleep 10
+done
 
-if [[ $(echo $?) -ne 0 ]]; then
-  gcloud infra-manager previews describe projects/${project_id}/locations/${location}/previews/preview-$SHORT_SHA
-  exit 1
-else
-  exit 0
-fi
+gcloud infra-manager previews describe projects/${project_id}/locations/${location}/previews/preview-$SHORT_SHA
+exit 1

--- a/modules/tf_cloudbuild_builder/README.md
+++ b/modules/tf_cloudbuild_builder/README.md
@@ -37,6 +37,7 @@ This module creates:
 | build\_timeout | Amount of time the build should be allowed to run, to second granularity. Format is the number of seconds followed by s. | `string` | `"600s"` | no |
 | cb\_logs\_bucket\_force\_destroy | When deleting the bucket for storing CloudBuild logs, this boolean option will delete all contained objects. If false, Terraform will fail to delete buckets which contain objects. | `bool` | `false` | no |
 | cloudbuild\_sa | Custom SA email to be used by the CloudBuild trigger. Defaults to being created if empty. | `string` | `""` | no |
+| cloudbuild\_sa\_name | Custom account\_id for the Cloud Build service account when created. Defaults to 'tf-cb-builder-sa'. | `string` | `"tf-cb-builder-sa"` | no |
 | dockerfile\_repo\_dir | The directory inside the repo where the Dockerfile is located. If empty defaults to repo root. | `string` | `""` | no |
 | dockerfile\_repo\_ref | The branch or tag to use. Use refs/heads/branchname for branches or refs/tags/tagname for tags. | `string` | `"refs/heads/main"` | no |
 | dockerfile\_repo\_type | Type of repo | `string` | `"CLOUD_SOURCE_REPOSITORIES"` | no |
@@ -55,6 +56,7 @@ This module creates:
 | workflow\_name | Name of the workflow managing builds. | `string` | `"terraform-runner-workflow"` | no |
 | workflow\_region | The region of the workflow. | `string` | `"us-central1"` | no |
 | workflow\_sa | Custom SA email to be used by the workflow. Defaults to being created if empty. | `string` | `""` | no |
+| workflow\_sa\_name | Custom account\_id for the Workflow service account when created. Defaults to 'terraform-runner-workflow-sa'. | `string` | `"terraform-runner-workflow-sa"` | no |
 | workflow\_schedule | The workflow frequency, in cron syntax | `string` | `"0 8 * * *"` | no |
 
 ## Outputs

--- a/modules/tf_cloudbuild_builder/cb.tf
+++ b/modules/tf_cloudbuild_builder/cb.tf
@@ -102,14 +102,16 @@ resource "google_cloudbuild_trigger" "build_trigger" {
 
   depends_on = [
     google_artifact_registry_repository_iam_member.push_images,
-    google_project_iam_member.logs_writer
+    google_project_iam_member.logs_writer,
+    google_storage_bucket_iam_member.member,
+    google_sourcerepo_repository_iam_member.member,
   ]
 }
 
 resource "google_service_account" "cb_sa" {
   count                        = var.cloudbuild_sa == "" ? 1 : 0
   project                      = var.project_id
-  account_id                   = "tf-cb-builder-sa"
+  account_id                   = var.cloudbuild_sa_name
   display_name                 = "SA for Terraform builder build trigger. Managed by Terraform."
   create_ignore_already_exists = true
 }

--- a/modules/tf_cloudbuild_builder/variables.tf
+++ b/modules/tf_cloudbuild_builder/variables.tf
@@ -43,6 +43,12 @@ variable "workflow_sa" {
   default     = ""
 }
 
+variable "workflow_sa_name" {
+  description = "Custom account_id for the Workflow service account when created. Defaults to 'terraform-runner-workflow-sa'."
+  type        = string
+  default     = "terraform-runner-workflow-sa"
+}
+
 variable "workflow_deletion_protection" {
   description = "Whether Terraform will be prevented from destroying the workflow. When the field is set to true or unset in Terraform state, a `terraform apply` or `terraform destroy` that would delete the workflow will fail. When the field is set to false, deleting the workflow is allowed."
   type        = bool
@@ -53,6 +59,12 @@ variable "cloudbuild_sa" {
   description = "Custom SA email to be used by the CloudBuild trigger. Defaults to being created if empty."
   type        = string
   default     = ""
+}
+
+variable "cloudbuild_sa_name" {
+  description = "Custom account_id for the Cloud Build service account when created. Defaults to 'tf-cb-builder-sa'."
+  type        = string
+  default     = "tf-cb-builder-sa"
 }
 
 variable "build_timeout" {

--- a/modules/tf_cloudbuild_builder/workflow.tf
+++ b/modules/tf_cloudbuild_builder/workflow.tf
@@ -30,7 +30,7 @@ locals {
 resource "google_service_account" "workflow_sa" {
   count                        = var.workflow_sa == "" ? 1 : 0
   project                      = var.project_id
-  account_id                   = "terraform-runner-workflow-sa"
+  account_id                   = var.workflow_sa_name
   display_name                 = "SA for TF Builder Workflow. Managed by Terraform."
   create_ignore_already_exists = true
 }
@@ -81,4 +81,11 @@ resource "google_cloud_scheduler_job" "trigger_workflow" {
       service_account_email = local.workflow_sa
     }
   }
+
+  depends_on = [
+    google_project_iam_member.invoke_workflow_scheduler,
+    google_project_iam_member.trigger_builds,
+    google_service_account_iam_member.use_cb_sa,
+    google_artifact_registry_repository_iam_member.workflow_list,
+  ]
 }

--- a/modules/tf_cloudbuild_workspace/cb.tf
+++ b/modules/tf_cloudbuild_workspace/cb.tf
@@ -167,6 +167,13 @@ resource "google_cloudbuild_trigger" "triggers" {
   ignored_files   = var.cloudbuild_ignored_files
 
   depends_on = [
-    google_project_iam_member.cb_sa_roles
+    google_project_iam_member.cb_sa_roles,
+    google_project_iam_member.cb_sa_logging,
+    google_storage_bucket_iam_member.artifacts_admin,
+    google_storage_bucket_iam_member.log_admin,
+    google_storage_bucket_iam_member.state_admin,
+    google_service_account_iam_member.cb_service_agent_impersonate,
+    google_service_account_iam_member.cb_sa_self,
+    google_sourcerepo_repository_iam_member.member,
   ]
 }

--- a/test/integration/cloudbuild_repo_connection_gitlab/cloudbuild_repo_connection_gitlab_test.go
+++ b/test/integration/cloudbuild_repo_connection_gitlab/cloudbuild_repo_connection_gitlab_test.go
@@ -19,6 +19,7 @@ import (
 	"regexp"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/GoogleCloudPlatform/cloud-foundation-toolkit/infra/blueprint-test/pkg/gcloud"
 	"github.com/GoogleCloudPlatform/cloud-foundation-toolkit/infra/blueprint-test/pkg/tft"
@@ -35,6 +36,7 @@ func TestCloudBuildRepoConnectionGitLab(t *testing.T) {
 	gitlabPAT := cftutils.ValFromEnv(t, "IM_GITLAB_PAT")
 	client := utils.NewGitLabClient(t, gitlabPAT, gitlabProjectName)
 	client.GetProject()
+	client.CleanStaleWebhooks(1 * time.Hour)
 
 	resourcesLocation := "us-central1"
 	vars := map[string]interface{}{

--- a/test/integration/im_cloudbuild_workspace_gitlab/im_cloudbuild_workspace_gitlab_test.go
+++ b/test/integration/im_cloudbuild_workspace_gitlab/im_cloudbuild_workspace_gitlab_test.go
@@ -38,6 +38,7 @@ func TestIMCloudBuildWorkspaceGitLab(t *testing.T) {
 	gitlabPAT := cftutils.ValFromEnv(t, "IM_GITLAB_PAT")
 	client := utils.NewGitLabClient(t, gitlabPAT, gitlabProjectName)
 	client.GetProject()
+	client.CleanStaleWebhooks(1 * time.Hour)
 
 	vars := map[string]interface{}{
 		"im_gitlab_pat":  gitlabPAT,

--- a/test/integration/tf_cloudbuild_builder_simple/tf_cloudbuild_builder_simple_test.go
+++ b/test/integration/tf_cloudbuild_builder_simple/tf_cloudbuild_builder_simple_test.go
@@ -122,7 +122,7 @@ func TestTFCloudBuildBuilder(t *testing.T) {
 		}
 		utils.Poll(t, pollCloudBuild(buildListCmd), 100, 10*time.Second)
 
-		images := gcloud.Runf(t, "artifacts docker images list %s --include-tags", artifactRepoDockerRegistry).Array()
+		images := gcloud.Runf(t, "artifacts docker images list %s --include-tags --filter='TAGS:*'", artifactRepoDockerRegistry).Array()
 		assert.Equal(1, len(images), "only one image is in registry")
 		imageTags := strings.Split(images[0].Get("tags").String(), ",")
 		assert.Equal(3, len(imageTags), "image has three tags")

--- a/test/integration/tf_cloudbuild_builder_simple_github/tf_cloudbuild_builder_simple_github_test.go
+++ b/test/integration/tf_cloudbuild_builder_simple_github/tf_cloudbuild_builder_simple_github_test.go
@@ -70,12 +70,12 @@ func TestTFCloudBuildBuilderGitHub(t *testing.T) {
 
 		workflowOP := gcloud.Runf(t, "workflows describe %s", workflowID)
 		assert.Contains(workflowOP.Get("name").String(), "terraform-runner-workflow-gh", "has the correct name")
-		assert.Equal(fmt.Sprintf("projects/%s/serviceAccounts/terraform-runner-workflow-sa@%s.iam.gserviceaccount.com", projectID, projectID), workflowOP.Get("serviceAccount").String(), "uses expected SA")
+		assert.Equal(fmt.Sprintf("projects/%s/serviceAccounts/tf-workflow-sa-gh@%s.iam.gserviceaccount.com", projectID, projectID), workflowOP.Get("serviceAccount").String(), "uses expected SA")
 
 		cloudBuildOP := gcloud.Runf(t, "beta builds triggers describe %s --project %s --region %s", triggerId, projectID, location)
 		log.Print(cloudBuildOP)
 		assert.Equal("tf-cloud-builder-build-gh", cloudBuildOP.Get("name").String(), "has the correct name")
-		assert.Equal(fmt.Sprintf("projects/%s/serviceAccounts/tf-cb-builder-sa@%s.iam.gserviceaccount.com", projectID, projectID), cloudBuildOP.Get("serviceAccount").String(), "uses expected SA")
+		assert.Equal(fmt.Sprintf("projects/%s/serviceAccounts/tf-cb-builder-sa-gh@%s.iam.gserviceaccount.com", projectID, projectID), cloudBuildOP.Get("serviceAccount").String(), "uses expected SA")
 		assert.Equal(repositoryID, cloudBuildOP.Get("sourceToBuild.repository").String(), "is connected to expected repo")
 		expectedSubsts := []string{"_TERRAFORM_FULL_VERSION", "_TERRAFORM_MAJOR_VERSION", "_TERRAFORM_MINOR_VERSION"}
 		gotSubsts := cloudBuildOP.Get("substitutions").Map()
@@ -142,7 +142,7 @@ func TestTFCloudBuildBuilderGitHub(t *testing.T) {
 		cftutils.Poll(t, pollCloudBuild(buildListCmd), 100, 10*time.Second)
 
 		// Check if the images where created
-		images := gcloud.Runf(t, "artifacts docker images list %s --include-tags", artifactRepoDockerRegistry).Array()
+		images := gcloud.Runf(t, "artifacts docker images list %s --include-tags --filter='TAGS:*'", artifactRepoDockerRegistry).Array()
 		assert.Equal(1, len(images), "only one image is in registry")
 		imageTags := strings.Split(images[0].Get("tags").String(), ",")
 		assert.Equal(3, len(imageTags), "image has three tags")

--- a/test/integration/tf_cloudbuild_builder_simple_gitlab/tf_cloudbuild_builder_simple_gitlab_test.go
+++ b/test/integration/tf_cloudbuild_builder_simple_gitlab/tf_cloudbuild_builder_simple_gitlab_test.go
@@ -37,6 +37,7 @@ func TestTFCloudBuildBuilderGitLab(t *testing.T) {
 	gitlabPAT := cftutils.ValFromEnv(t, "IM_GITLAB_PAT")
 	client := utils.NewGitLabClient(t, gitlabPAT, gitlabProjectName)
 	client.GetProject()
+	client.CleanStaleWebhooks(1 * time.Hour)
 
 	// Testing the module's feature of appending the ".git" suffix if it's missing
 	// repoURL := strings.TrimSuffix(client.repository.GetCloneURL(), ".git")
@@ -67,12 +68,12 @@ func TestTFCloudBuildBuilderGitLab(t *testing.T) {
 
 		workflowOP := gcloud.Runf(t, "workflows describe %s", workflowID)
 		assert.Contains(workflowOP.Get("name").String(), "terraform-runner-workflow-gl", "has the correct name")
-		assert.Equal(fmt.Sprintf("projects/%s/serviceAccounts/terraform-runner-workflow-sa@%s.iam.gserviceaccount.com", projectID, projectID), workflowOP.Get("serviceAccount").String(), "uses expected SA")
+		assert.Equal(fmt.Sprintf("projects/%s/serviceAccounts/tf-workflow-sa-gl@%s.iam.gserviceaccount.com", projectID, projectID), workflowOP.Get("serviceAccount").String(), "uses expected SA")
 
 		cloudBuildOP := gcloud.Runf(t, "beta builds triggers describe %s --project %s --region %s", triggerId, projectID, location)
 		log.Print(cloudBuildOP)
 		assert.Equal("tf-cloud-builder-build-gl", cloudBuildOP.Get("name").String(), "has the correct name")
-		assert.Equal(fmt.Sprintf("projects/%s/serviceAccounts/tf-cb-builder-sa@%s.iam.gserviceaccount.com", projectID, projectID), cloudBuildOP.Get("serviceAccount").String(), "uses expected SA")
+		assert.Equal(fmt.Sprintf("projects/%s/serviceAccounts/tf-cb-builder-sa-gl@%s.iam.gserviceaccount.com", projectID, projectID), cloudBuildOP.Get("serviceAccount").String(), "uses expected SA")
 		assert.Equal(repositoryID, cloudBuildOP.Get("sourceToBuild.repository").String(), "is connected to expected repo")
 		expectedSubsts := []string{"_TERRAFORM_FULL_VERSION", "_TERRAFORM_MAJOR_VERSION", "_TERRAFORM_MINOR_VERSION"}
 		gotSubsts := cloudBuildOP.Get("substitutions").Map()
@@ -139,7 +140,7 @@ func TestTFCloudBuildBuilderGitLab(t *testing.T) {
 		cftutils.Poll(t, pollCloudBuild(buildListCmd), 100, 10*time.Second)
 
 		// Check if the images where created
-		images := gcloud.Runf(t, "artifacts docker images list %s --include-tags", artifactRepoDockerRegistry).Array()
+		images := gcloud.Runf(t, "artifacts docker images list %s --include-tags --filter='TAGS:*'", artifactRepoDockerRegistry).Array()
 		assert.Equal(1, len(images), "only one image is in registry")
 		imageTags := strings.Split(images[0].Get("tags").String(), ",")
 		assert.Equal(3, len(imageTags), "image has three tags")

--- a/test/integration/tf_cloudbuild_workspace_simple_gitlab/tf_cloudbuild_workspace_simple_gitlab_test.go
+++ b/test/integration/tf_cloudbuild_workspace_simple_gitlab/tf_cloudbuild_workspace_simple_gitlab_test.go
@@ -37,6 +37,7 @@ func TestCloudBuildWorkspaceSimpleGitLab(t *testing.T) {
 	gitlabPAT := cftutils.ValFromEnv(t, "IM_GITLAB_PAT")
 	client := utils.NewGitLabClient(t, gitlabPAT, gitlabProjectName)
 	client.GetProject()
+	client.CleanStaleWebhooks(1 * time.Hour)
 
 	vars := map[string]interface{}{
 		"gitlab_authorizer_credential":      gitlabPAT,

--- a/test/integration/utils/github_client.go
+++ b/test/integration/utils/github_client.go
@@ -92,8 +92,12 @@ func (gh *GitHubClient) ClosePullRequest(ctx context.Context, pr *github.PullReq
 
 func (gh *GitHubClient) GetRepository(ctx context.Context) *github.Repository {
 	repo, resp, err := gh.client.Repositories.Get(ctx, gh.owner, gh.repoName)
-	if resp.StatusCode != 404 && err != nil {
-		gh.t.Fatal(err.Error())
+	if err != nil {
+		status := 0
+		if resp != nil {
+			status = resp.StatusCode
+		}
+		gh.t.Fatalf("failed to retrieve GitHub repository %s/%s (status code %d): %v", gh.owner, gh.repoName, status, err)
 	}
 	gh.Repository = repo
 	return repo

--- a/test/integration/utils/gitlab_client.go
+++ b/test/integration/utils/gitlab_client.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/xanzy/go-gitlab"
 )
@@ -57,8 +58,12 @@ func (gl *GitLabClient) ProjectName() string {
 
 func (gl *GitLabClient) GetProject() *gitlab.Project {
 	proj, resp, err := gl.client.Projects.GetProject(gl.ProjectName(), nil)
-	if resp.StatusCode != 404 && err != nil {
-		gl.t.Fatalf("got status code %d, error %s", resp.StatusCode, err.Error())
+	if err != nil {
+		status := 0
+		if resp != nil {
+			status = resp.StatusCode
+		}
+		gl.t.Fatalf("failed to retrieve GitLab project %s (status code %d): %v", gl.ProjectName(), status, err)
 	}
 	gl.Project = proj
 	return proj
@@ -148,3 +153,43 @@ func (gl *GitLabClient) DeleteWebhookByKey(webhookKey string) {
 		opts.Page = resp.NextPage
 	}
 }
+
+// CleanStaleWebhooks removes Cloud Build webhooks older than maxAge (e.g. 1 hour)
+// to prevent hook limit exhaustion while preserving active webhooks from concurrent test runs.
+func (gl *GitLabClient) CleanStaleWebhooks(maxAge time.Duration) {
+	opts := &gitlab.ListProjectHooksOptions{
+		PerPage: 100,
+		Page:    1,
+	}
+
+	for {
+		hooks, resp, err := gl.client.Projects.ListProjectHooks(gl.ProjectName(), opts)
+		if err != nil {
+			gl.t.Logf("Warning: could not list GitLab webhooks for %s: %v", gl.ProjectName(), err)
+			return
+		}
+
+		gl.t.Logf("GitLab project %s currently has %d/100 webhooks registered", gl.ProjectName(), len(hooks))
+
+		for _, hook := range hooks {
+			if strings.Contains(hook.URL, "cloudbuild.googleapis.com") {
+				if hook.CreatedAt != nil && time.Since(*hook.CreatedAt) > maxAge {
+					_, err := gl.client.Projects.DeleteProjectHook(gl.ProjectName(), hook.ID)
+					if err != nil {
+						gl.t.Logf("Warning: failed to delete stale webhook ID %d: %v", hook.ID, err)
+					} else {
+						gl.t.Logf("Cleaned up stale GitLab webhook ID %d (age: %v, URL: %s)", hook.ID, time.Since(*hook.CreatedAt).Round(time.Minute), hook.URL)
+					}
+				} else if hook.CreatedAt != nil {
+					gl.t.Logf("Preserving active/recent webhook ID %d (age: %v)", hook.ID, time.Since(*hook.CreatedAt).Round(time.Second))
+				}
+			}
+		}
+
+		if resp.NextPage == 0 {
+			break
+		}
+		opts.Page = resp.NextPage
+	}
+}
+


### PR DESCRIPTION
- modules/im_cloudbuild_workspace: Add retry loop in create-preview.sh.tftpl to handle IAM propagation latency and transient API errors.
- modules/im_cloudbuild_workspace: Add missing depends_on for SA IAM roles and VCS secret accessor bindings.
- modules/tf_cloudbuild_workspace: Add missing depends_on for logging, bucket admins, CSR viewer, and SA self-impersonation roles.
- modules/tf_cloudbuild_builder: Add cloudbuild_sa_name and workflow_sa_name variables to isolate service accounts across parallel test suites.
- modules/tf_cloudbuild_builder: Add missing depends_on for storage admin, CSR viewer, and workflow Artifact Registry reader roles.
- modules/cloudbuild_repo_connection: Add troubleshooting documentation for GitLab webhook registration (HTTP 422 errors).
- examples/tf_cloudbuild_builder_simple_{github,gitlab}: Configure distinct service account names to prevent teardown collisions.
- test/integration: Filter for tagged images in builder integration tests to ignore untagged orphaned image digests.
- test/integration: Add TTL-based stale webhook cleanup and enhanced diagnostic logging across all GitLab integration tests.
- test/integration: Improve error handling in GitLab and GitHub test clients to fail fast on 404/auth errors.
- build/int.cloudbuild.yaml: Decouple builder teardown dependencies to run independently per test suite.