### PR TITLE
fix!: remove terraform-tools from docker images

### DIFF
--- a/examples/tf_cloudbuild_builder_simple/Dockerfile
+++ b/examples/tf_cloudbuild_builder_simple/Dockerfile
@@ -20,7 +20,7 @@ ARG TERRAFORM_VERSION=1.1.0
 ENV ENV_TERRAFORM_VERSION=$TERRAFORM_VERSION
 
 RUN apt-get update && \
-    /builder/google-cloud-sdk/bin/gcloud -q components install alpha beta terraform-tools && \
+    /builder/google-cloud-sdk/bin/gcloud -q components install alpha beta && \
     apt-get -y install curl jq unzip git ca-certificates gnupg && \
     curl https://releases.hashicorp.com/terraform/${ENV_TERRAFORM_VERSION}/terraform_${ENV_TERRAFORM_VERSION}_linux_amd64.zip --output terraform_${ENV_TERRAFORM_VERSION}_linux_amd64.zip && \
     curl https://releases.hashicorp.com/terraform/${ENV_TERRAFORM_VERSION}/terraform_${ENV_TERRAFORM_VERSION}_SHA256SUMS.sig --output terraform_SHA256SUMS.sig  && \

--- a/examples/tf_cloudbuild_builder_simple_github/Dockerfile
+++ b/examples/tf_cloudbuild_builder_simple_github/Dockerfile
@@ -20,7 +20,7 @@ ARG TERRAFORM_VERSION=1.1.0
 ENV ENV_TERRAFORM_VERSION=$TERRAFORM_VERSION
 
 RUN apt-get update && \
-    /builder/google-cloud-sdk/bin/gcloud -q components install alpha beta terraform-tools && \
+    /builder/google-cloud-sdk/bin/gcloud -q components install alpha beta && \
     apt-get -y install curl jq unzip git ca-certificates gnupg && \
     curl https://releases.hashicorp.com/terraform/${ENV_TERRAFORM_VERSION}/terraform_${ENV_TERRAFORM_VERSION}_linux_amd64.zip --output terraform_${ENV_TERRAFORM_VERSION}_linux_amd64.zip && \
     curl https://releases.hashicorp.com/terraform/${ENV_TERRAFORM_VERSION}/terraform_${ENV_TERRAFORM_VERSION}_SHA256SUMS.sig --output terraform_SHA256SUMS.sig  && \

--- a/examples/tf_cloudbuild_builder_simple_gitlab/Dockerfile
+++ b/examples/tf_cloudbuild_builder_simple_gitlab/Dockerfile
@@ -20,7 +20,7 @@ ARG TERRAFORM_VERSION=1.1.0
 ENV ENV_TERRAFORM_VERSION=$TERRAFORM_VERSION
 
 RUN apt-get update && \
-    /builder/google-cloud-sdk/bin/gcloud -q components install alpha beta terraform-tools && \
+    /builder/google-cloud-sdk/bin/gcloud -q components install alpha beta && \
     apt-get -y install curl jq unzip git ca-certificates gnupg && \
     curl https://releases.hashicorp.com/terraform/${ENV_TERRAFORM_VERSION}/terraform_${ENV_TERRAFORM_VERSION}_linux_amd64.zip --output terraform_${ENV_TERRAFORM_VERSION}_linux_amd64.zip && \
     curl https://releases.hashicorp.com/terraform/${ENV_TERRAFORM_VERSION}/terraform_${ENV_TERRAFORM_VERSION}_SHA256SUMS.sig --output terraform_SHA256SUMS.sig  && \

--- a/modules/cloudbuild/cloudbuild_builder/Dockerfile
+++ b/modules/cloudbuild/cloudbuild_builder/Dockerfile
@@ -23,7 +23,7 @@ ENV ENV_TERRAFORM_VERSION=$TERRAFORM_VERSION
 ENV ENV_TERRAFORM_VERSION_SHA256SUM=$TERRAFORM_VERSION_SHA256SUM
 
 RUN apt-get update && \
-    apt-get -y install curl jq unzip git ca-certificates google-cloud-sdk-terraform-tools && \
+    apt-get -y install curl jq unzip git ca-certificates && \
     curl https://releases.hashicorp.com/terraform/${ENV_TERRAFORM_VERSION}/terraform_${ENV_TERRAFORM_VERSION}_linux_amd64.zip \
       > terraform_linux_amd64.zip && \
     echo "${ENV_TERRAFORM_VERSION_SHA256SUM} terraform_linux_amd64.zip" > terraform_SHA256SUMS && \


### PR DESCRIPTION
This PR removes dependencies `terraform-tools` and `google-cloud-sdk-terraform-tools` from the docker images created for Cloud Build 